### PR TITLE
fix: Address multiple bugs and code issues

### DIFF
--- a/AWDLControl/AWDLControl/AWDLControlApp.swift
+++ b/AWDLControl/AWDLControl/AWDLControlApp.swift
@@ -66,8 +66,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             setupGameModeDetector()
         }
 
-        // Observe preference changes from widget
-        monitoringObserver = NotificationCenter.default.addObserver(
+        // Observe preference changes from widget (uses distributed notifications for cross-process)
+        monitoringObserver = DistributedNotificationCenter.default().addObserver(
             forName: .awdlMonitoringStateChanged,
             object: nil,
             queue: .main
@@ -117,7 +117,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if let observer = monitoringObserver {
-            NotificationCenter.default.removeObserver(observer)
+            DistributedNotificationCenter.default().removeObserver(observer)
         }
         if let observer = controlCenterObserver {
             NotificationCenter.default.removeObserver(observer)

--- a/AWDLControl/AWDLControl/AWDLMonitor.swift
+++ b/AWDLControl/AWDLControl/AWDLMonitor.swift
@@ -23,7 +23,23 @@ class AWDLMonitor {
     /// Expected daemon version - should match DAEMON_VERSION in awdl_monitor_daemon.c
     static let expectedDaemonVersion = "1.0.0"
 
-    private var isMonitoring = false
+    /// Lock for thread-safe access to isMonitoring flag
+    private let stateLock = NSLock()
+    private var _isMonitoring = false
+
+    /// Thread-safe access to monitoring state
+    private var isMonitoring: Bool {
+        get {
+            stateLock.lock()
+            defer { stateLock.unlock() }
+            return _isMonitoring
+        }
+        set {
+            stateLock.lock()
+            _isMonitoring = newValue
+            stateLock.unlock()
+        }
+    }
 
     /// Callback for UI updates
     var onStateChange: (() -> Void)?
@@ -403,6 +419,7 @@ class AWDLMonitor {
     }
 
     /// Wait for daemon to reach expected state with timeout
+    /// Uses RunLoop to avoid completely blocking the main thread
     private func waitForDaemonState(running: Bool, timeout: TimeInterval) -> Bool {
         log.debug("Waiting for daemon state: running=\(running), timeout=\(timeout)s")
 
@@ -415,7 +432,8 @@ class AWDLMonitor {
                 log.debug("Daemon reached expected state in \(String(format: "%.2f", elapsed))s")
                 return true
             }
-            Thread.sleep(forTimeInterval: checkInterval)
+            // Use RunLoop instead of Thread.sleep to allow event processing
+            RunLoop.current.run(until: Date(timeIntervalSinceNow: checkInterval))
         }
 
         log.warning("Timeout waiting for daemon state (expected running=\(running))")

--- a/AWDLControl/AWDLControl/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControl/AWDLPreferences.swift
@@ -29,7 +29,13 @@ class AWDLPreferences {
         }
         set {
             defaults?.set(newValue, forKey: monitoringEnabledKey)
-            NotificationCenter.default.post(name: .awdlMonitoringStateChanged, object: nil)
+            // Use distributed notification for cross-process communication with widget
+            DistributedNotificationCenter.default().postNotificationName(
+                .awdlMonitoringStateChanged,
+                object: nil,
+                userInfo: nil,
+                deliverImmediately: true
+            )
         }
     }
 

--- a/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
@@ -23,8 +23,14 @@ class AWDLPreferences {
         set {
             defaults?.set(newValue, forKey: monitoringEnabledKey)
 
-            // Post notification for app to respond
-            NotificationCenter.default.post(name: .awdlMonitoringStateChanged, object: nil)
+            // Use distributed notification for cross-process communication
+            // NotificationCenter.default only works within the same process
+            DistributedNotificationCenter.default().postNotificationName(
+                .awdlMonitoringStateChanged,
+                object: nil,
+                userInfo: nil,
+                deliverImmediately: true
+            )
         }
     }
 

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,8 @@ echo ""
 
 # Build Swift app
 echo "📱 Building Swift app..."
+# Temporarily disable set -e to handle xcodebuild failure gracefully
+set +e
 xcodebuild -project AWDLControl/AWDLControl.xcodeproj \
            -target AWDLControl \
            -target AWDLControlWidget \
@@ -24,8 +26,10 @@ xcodebuild -project AWDLControl/AWDLControl.xcodeproj \
            CODE_SIGNING_REQUIRED=NO \
            CODE_SIGNING_ALLOWED=NO \
            > /tmp/xcodebuild.log 2>&1
+XCODE_EXIT=$?
+set -e
 
-if [ $? -eq 0 ]; then
+if [ $XCODE_EXIT -eq 0 ]; then
     echo "✅ App built successfully"
     echo ""
 


### PR DESCRIPTION
- C daemon: Increase routing message buffer size from ~100 bytes to 1024
  bytes to prevent potential truncation of RTM_IFINFO messages that may
  include sockaddr_dl and other variable-length data

- Widget AWDLPreferences: Change defaults from computed property to lazy
  var to avoid creating new UserDefaults instance on every access

- AWDLMonitor: Remove unused variables bundledDaemonSource and
  bundledPlistSource that were defined but never used

- GameModeDetector: Add deinit to ensure timer is invalidated when
  object is deallocated, preventing potential timer leak