### PR TITLE
fix: Multiple bug fixes and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A macOS menu bar app that disables AWDL to eliminate network latency spikes during gaming and video calls.
 
+<a href="https://www.buymeacoffee.com/oliverames" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/arial-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
 ## The Problem
 
 AWDL (Apple Wireless Direct Link) powers AirDrop, AirPlay, and Handoff. It also causes:
@@ -56,6 +58,8 @@ Access Settings from the menu bar to configure:
 ### Control Center Widget (Beta)
 
 Enable in Settings to add an AWDL toggle to the macOS Control Center. When enabled, the menu bar icon is hidden.
+
+> **Note**: The Control Center widget requires the app to be code-signed with a Developer ID certificate. When building from source without code signing, this feature is disabled and the menu bar icon remains visible. To enable, open the project in Xcode, configure signing with your Apple Developer account, and rebuild.
 
 ### Game Mode Auto-Detect (Beta)
 

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,12 @@ echo ""
 
 # Build Swift app
 echo "📱 Building Swift app..."
+
+# Note: Building without code signing. Control Center widget requires code signing
+# to work. To enable signing, open the project in Xcode and configure signing there.
+echo "⚠️  Building without code signing (Control Center widget will not be available)"
+echo "   To enable: Open project in Xcode → Signing & Capabilities → Select your team"
+
 # Temporarily disable set -e to handle xcodebuild failure gracefully
 set +e
 xcodebuild -project AWDLControl/AWDLControl.xcodeproj \


### PR DESCRIPTION
## Summary
- Fix duplicate `log` variable declaration causing build failure
- Fix Settings menu item not opening window (create window directly instead of using unreliable selector)
- Add Control Center widget safety mechanism (automatically reverts to menu bar if widget unavailable due to missing code signing)
- Improve Settings window styling for macOS 26 glass effect
- Add Buy Me a Coffee button to README
- Document Control Center widget code signing requirement in README
- Update build script to show code signing status

## Test plan
- [x] Build completes successfully with `./build.sh`
- [x] Settings window opens from menu bar
- [x] Settings window has proper macOS 26 glass appearance
- [x] Control Center widget toggle is disabled when code signing unavailable
- [x] Menu bar icon remains visible when widget unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)