### PR TITLE
fix: Address 35 code review issues for helper activation and code signing

### DIFF
--- a/AWDLControl/AWDLControl.xcodeproj/project.pbxproj
+++ b/AWDLControl/AWDLControl.xcodeproj/project.pbxproj
@@ -533,6 +533,7 @@
 		HelperDebugConfig /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				DEAD_CODE_STRIPPING = YES;
@@ -548,6 +549,7 @@
 		HelperReleaseConfig /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				DEAD_CODE_STRIPPING = YES;

--- a/AWDLControl/AWDLControl/AWDLControl-Bridging-Header.h
+++ b/AWDLControl/AWDLControl/AWDLControl-Bridging-Header.h
@@ -1,5 +1,11 @@
 //
-//  Use this file to import your target's public headers that you would like to expose to Swift.
+//  AWDLControl-Bridging-Header.h
+//  AWDLControl
+//
+//  Bridging header to expose Objective-C interfaces to Swift.
+//
+//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
 //
 
 #import "../Common/HelperProtocol.h"

--- a/AWDLControl/AWDLControl/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControl/AWDLPreferences.swift
@@ -1,4 +1,17 @@
+//
+//  AWDLPreferences.swift
+//  AWDLControl
+//
+//  Manages shared state between app and widget using App Groups.
+//
+//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
+//
+
 import Foundation
+import os.log
+
+private let log = Logger(subsystem: "com.awdlcontrol.app", category: "Preferences")
 
 /// Manages shared state between app and widget using App Groups
 class AWDLPreferences {
@@ -14,9 +27,10 @@ class AWDLPreferences {
     private lazy var defaults: UserDefaults? = {
         // Use standard UserDefaults if App Groups aren't available
         guard let suite = UserDefaults(suiteName: appGroupID) else {
-            print("AWDLPreferences: Failed to create App Group suite, using standard defaults")
+            log.error("Failed to create App Group suite '\(self.appGroupID)', using standard defaults")
             return UserDefaults.standard
         }
+        log.debug("Successfully connected to App Group suite")
         return suite
     }()
 
@@ -29,6 +43,7 @@ class AWDLPreferences {
         }
         set {
             defaults?.set(newValue, forKey: monitoringEnabledKey)
+            defaults?.synchronize()
             // Use distributed notification for cross-process communication with widget
             DistributedNotificationCenter.default().postNotificationName(
                 .awdlMonitoringStateChanged,
@@ -84,8 +99,9 @@ class AWDLPreferences {
 }
 
 extension Notification.Name {
-    static let awdlMonitoringStateChanged = Notification.Name("AWDLMonitoringStateChanged")
-    static let controlCenterModeChanged = Notification.Name("ControlCenterModeChanged")
-    static let gameModeAutoDetectChanged = Notification.Name("GameModeAutoDetectChanged")
-    static let dockIconVisibilityChanged = Notification.Name("DockIconVisibilityChanged")
+    // Use namespaced notification names to avoid collisions with other apps
+    static let awdlMonitoringStateChanged = Notification.Name("com.awdlcontrol.notification.MonitoringStateChanged")
+    static let controlCenterModeChanged = Notification.Name("com.awdlcontrol.notification.ControlCenterModeChanged")
+    static let gameModeAutoDetectChanged = Notification.Name("com.awdlcontrol.notification.GameModeAutoDetectChanged")
+    static let dockIconVisibilityChanged = Notification.Name("com.awdlcontrol.notification.DockIconVisibilityChanged")
 }

--- a/AWDLControl/AWDLControlHelper/AWDLMonitor.h
+++ b/AWDLControl/AWDLControlHelper/AWDLMonitor.h
@@ -5,6 +5,9 @@
 //  Monitors AWDL interface state using AF_ROUTE socket.
 //  Based on james-howard/AWDLControl and jamestut/awdlkiller.
 //
+//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
+//
 
 #import <Foundation/Foundation.h>
 

--- a/AWDLControl/AWDLControlHelper/com.awdlcontrol.helper.plist
+++ b/AWDLControl/AWDLControlHelper/com.awdlcontrol.helper.plist
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.awdlcontrol.helper.plist
+  SMAppService daemon configuration for AWDLControlHelper
+
+  Copyright (c) 2025 Oliver Ames. All rights reserved.
+  Licensed under the MIT License.
+-->
 <plist version="1.0">
 <dict>
 	<key>Label</key>
@@ -11,6 +18,7 @@
 	<key>AssociatedBundleIdentifiers</key>
 	<array>
 		<string>com.awdlcontrol.app</string>
+		<string>com.awdlcontrol.app.widget</string>
 	</array>
 
 	<key>MachServices</key>
@@ -21,5 +29,16 @@
 
 	<key>RunAtLoad</key>
 	<true/>
+
+	<!-- Run as root to allow ioctl on network interfaces -->
+	<key>UserName</key>
+	<string>root</string>
+
+	<!-- Keep helper alive for responsive network control -->
+	<key>KeepAlive</key>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
 </dict>
 </plist>

--- a/AWDLControl/AWDLControlWidget/AWDLControlWidget.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLControlWidget.swift
@@ -1,3 +1,13 @@
+//
+//  AWDLControlWidget.swift
+//  AWDLControlWidget
+//
+//  Control Center widget for toggling AWDL blocking.
+//
+//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
+//
+
 import SwiftUI
 import WidgetKit
 import AppIntents

--- a/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
@@ -1,4 +1,17 @@
+//
+//  AWDLPreferences.swift
+//  AWDLControlWidget
+//
+//  Manages shared state between app and widget using App Groups.
+//
+//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
+//
+
 import Foundation
+import os.log
+
+private let log = Logger(subsystem: "com.awdlcontrol.app", category: "WidgetPreferences")
 
 /// Manages shared state between app and widget using App Groups
 /// Note: This file should be kept in sync with AWDLControl/AWDLPreferences.swift
@@ -18,9 +31,10 @@ class AWDLPreferences {
         guard let suite = UserDefaults(suiteName: appGroupID) else {
             // Fallback to standard defaults if app group fails
             // This matches the main app's behavior for consistency
-            print("AWDLPreferences: Failed to create App Group suite, using standard defaults")
+            log.error("Failed to create App Group suite '\(self.appGroupID)', using standard defaults")
             return UserDefaults.standard
         }
+        log.debug("Successfully connected to App Group suite")
         return suite
     }()
 
@@ -33,6 +47,7 @@ class AWDLPreferences {
         }
         set {
             defaults?.set(newValue, forKey: monitoringEnabledKey)
+            defaults?.synchronize()
 
             // Use distributed notification for cross-process communication
             // NotificationCenter.default only works within the same process
@@ -90,9 +105,10 @@ class AWDLPreferences {
 }
 
 extension Notification.Name {
-    static let awdlMonitoringStateChanged = Notification.Name("AWDLMonitoringStateChanged")
+    // Use a namespaced notification name to avoid collisions with other apps
+    static let awdlMonitoringStateChanged = Notification.Name("com.awdlcontrol.notification.MonitoringStateChanged")
     // These are defined in the main app but included here for reference:
-    // static let controlCenterModeChanged = Notification.Name("ControlCenterModeChanged")
-    // static let gameModeAutoDetectChanged = Notification.Name("GameModeAutoDetectChanged")
-    // static let dockIconVisibilityChanged = Notification.Name("DockIconVisibilityChanged")
+    // static let controlCenterModeChanged = Notification.Name("com.awdlcontrol.notification.ControlCenterModeChanged")
+    // static let gameModeAutoDetectChanged = Notification.Name("com.awdlcontrol.notification.GameModeAutoDetectChanged")
+    // static let dockIconVisibilityChanged = Notification.Name("com.awdlcontrol.notification.DockIconVisibilityChanged")
 }

--- a/AWDLControl/Common/HelperProtocol.h
+++ b/AWDLControl/Common/HelperProtocol.h
@@ -5,6 +5,9 @@
 //  XPC protocol for communication between main app and privileged helper daemon.
 //  Based on james-howard/AWDLControl SMAppService architecture.
 //
+//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
+//
 
 #import <Foundation/Foundation.h>
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
-set -e
+#
+# build.sh
+# Ping Warden (AWDLControl)
+#
+# Build script for the app, widget, and helper.
+#
+# Copyright (c) 2025 Oliver Ames. All rights reserved.
+# Licensed under the MIT License.
+#
+
+set -eo pipefail
 
 echo "🔨 Building Ping Warden v2.0..."
 echo ""
@@ -7,16 +17,46 @@ echo ""
 # Development Team ID (must match Xcode project settings)
 DEVELOPMENT_TEAM="PV3W52NDZ3"
 
+# Expected team ID in project file (for validation)
+PROJECT_FILE="AWDLControl/AWDLControl.xcodeproj/project.pbxproj"
+
+# Validate team ID matches project
+echo "🔍 Validating build configuration..."
+if [ -f "$PROJECT_FILE" ]; then
+    PROJECT_TEAM=$(grep -o 'DEVELOPMENT_TEAM = [^;]*' "$PROJECT_FILE" | head -1 | cut -d'"' -f2 | tr -d '=; ')
+    if [ -n "$PROJECT_TEAM" ] && [ "$PROJECT_TEAM" != "$DEVELOPMENT_TEAM" ]; then
+        echo "   ⚠️  Warning: DEVELOPMENT_TEAM mismatch"
+        echo "      Script: $DEVELOPMENT_TEAM"
+        echo "      Project: $PROJECT_TEAM"
+        echo "      Using project value..."
+        DEVELOPMENT_TEAM="$PROJECT_TEAM"
+    else
+        echo "   ✅ DEVELOPMENT_TEAM validated: $DEVELOPMENT_TEAM"
+    fi
+fi
+
 # Check if we can find a valid signing identity
+# Use exact pattern matching to avoid substring matches
 echo "🔍 Checking for Developer ID certificate..."
-if security find-identity -v -p codesigning | grep -q "Developer ID Application"; then
+AVAILABLE_CERTS=$(security find-identity -v -p codesigning 2>/dev/null || true)
+
+# First try to find an exact "Developer ID Application" certificate (not expired)
+if echo "$AVAILABLE_CERTS" | grep -E "\"Developer ID Application: [^\"]+\"$" | grep -v "CSSMERR" > /dev/null 2>&1; then
     SIGNING_IDENTITY="Developer ID Application"
     echo "   ✅ Found Developer ID Application certificate"
-elif security find-identity -v -p codesigning | grep -q "Apple Development"; then
+# Fall back to Apple Development
+elif echo "$AVAILABLE_CERTS" | grep -E "\"Apple Development: [^\"]+\"$" | grep -v "CSSMERR" > /dev/null 2>&1; then
     SIGNING_IDENTITY="Apple Development"
     echo "   ✅ Found Apple Development certificate"
+# Last resort: any development certificate
+elif echo "$AVAILABLE_CERTS" | grep -E "\"[^\"]+Development[^\"]+\"$" | grep -v "CSSMERR" > /dev/null 2>&1; then
+    SIGNING_IDENTITY=$(echo "$AVAILABLE_CERTS" | grep -E "\"[^\"]+Development[^\"]+\"$" | grep -v "CSSMERR" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+    echo "   ✅ Found certificate: $SIGNING_IDENTITY"
 else
     echo "   ❌ No valid signing certificate found!"
+    echo ""
+    echo "   Available certificates:"
+    echo "$AVAILABLE_CERTS" | grep -v "^$" | head -10 || echo "   (none)"
     echo ""
     echo "   To build this app, you need either:"
     echo "   - A Developer ID Application certificate (for distribution)"
@@ -30,6 +70,11 @@ echo ""
 
 # Build all targets with proper signing
 echo "📱 Building app, widget, and helper..."
+
+# Use tee to capture output while showing progress, handle signals properly
+BUILD_LOG="/tmp/xcodebuild.log"
+trap 'echo ""; echo "Build interrupted. Log saved to $BUILD_LOG"; exit 130' INT TERM
+
 xcodebuild -project AWDLControl/AWDLControl.xcodeproj \
            -target AWDLControl \
            -target AWDLControlWidget \
@@ -37,12 +82,13 @@ xcodebuild -project AWDLControl/AWDLControl.xcodeproj \
            -configuration Release \
            DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
            CODE_SIGN_STYLE=Automatic \
-           clean build \
-           > /tmp/xcodebuild.log 2>&1
+           clean build 2>&1 | tee "$BUILD_LOG" | grep -E "^(Build|Compile|Sign|error:|warning:|===)" || true
 
-XCODE_EXIT=$?
+# Check the actual exit status from xcodebuild (not from grep)
+XCODE_EXIT=${PIPESTATUS[0]}
 
 if [ $XCODE_EXIT -eq 0 ]; then
+    echo ""
     echo "✅ Build succeeded"
     echo ""
 
@@ -83,7 +129,7 @@ if [ $XCODE_EXIT -eq 0 ]; then
     # Re-sign the app bundle after adding helper with proper Developer ID
     echo "🔏 Signing app bundle with $SIGNING_IDENTITY..."
     codesign --force --deep --options runtime --sign "$SIGNING_IDENTITY" "$APP_BUNDLE"
-    echo "   ✅ App bundle signed with Developer ID"
+    echo "   ✅ App bundle signed"
 
     echo ""
 
@@ -132,9 +178,12 @@ if [ $XCODE_EXIT -eq 0 ]; then
     echo "   3. Approve in System Settings → Login Items (one-time)"
     echo ""
 else
-    echo "❌ Build failed. Check /tmp/xcodebuild.log for details"
+    echo ""
+    echo "❌ Build failed (exit code: $XCODE_EXIT)"
+    echo ""
+    echo "Build log saved to: $BUILD_LOG"
     echo ""
     echo "Last 50 lines of build log:"
-    tail -50 /tmp/xcodebuild.log
+    tail -50 "$BUILD_LOG"
     exit 1
 fi


### PR DESCRIPTION
Critical fixes (issues #1-8):
- Add CODE_SIGN_IDENTITY to helper target build settings
- Add widget to AssociatedBundleIdentifiers in helper plist
- Add XPC code signing requirement for production builds
- Add UserName=root to helper plist for ioctl permissions
- Fix XPC connection with .privileged option (correct for daemons)
- Fix race condition using dispatch_async instead of dispatch_sync
- Add app launch capability to widget toggle intent
- Add exit grace period to allow XPC reconnection

High priority fixes (issues #9-20):
- Replace print() with os_log in AWDLPreferences
- Add 60-second timeout to registration polling
- Fix thread safety in handleXPCInvalidation
- Remove unsafe force unwrap URLs (use nil-coalescing)
- Add XPC retry logic with exponential backoff
- Fix timer scheduling on main run loop for GameModeDetector
- Improve build.sh error handling with pipefail
- Add precise pattern matching for certificate detection
- Add DEVELOPMENT_TEAM validation in build.sh
- Document widget deployment target (14.0) vs app (13.0)

Medium priority fixes (issues #21-30):
- Extract team ID from project file in build.sh
- Add synchronization note for duplicate AWDLPreferences files
- Add cleanupFileDescriptors method to AWDLMonitor.m
- Standardize log subsystem across widget files
- Add accessibility labels to menu bar icon
- Team ID validation in build.sh
- Add _Static_assert for TARGETIFNAM size
- Fix file descriptor leak on init error paths
- Add proper error handling in setAWDLEnabled with verification
- Use namespaced notification names to avoid collisions

Low priority fixes (issues #31-35):
- Remove unused legacy SettingsView struct
- Document RTMSG_BUFFER_SIZE rationale
- Standardize plist formatting
- Add copyright headers to all source files
- Update documentation references