### PR TITLE
fix: Address 35 code review issues for helper activation and code signing

### DIFF
--- a/AWDLControl/AWDLControl/AWDLControlApp.swift
+++ b/AWDLControl/AWDLControl/AWDLControlApp.swift
@@ -651,11 +651,10 @@ class SettingsSplitViewController: NSSplitViewController {
         let newDetailController = NSHostingController(rootView: newDetailView)
 
         // Remove old detail view item first, then add new one
-        // Capture the item reference to avoid potential TOCTOU race
-        let items = splitViewItems
-        if items.count > 1 {
-            let itemToRemove = items[1]
-            removeSplitViewItem(itemToRemove)
+        // Use safe iteration to find and remove the detail item
+        // This ensures we don't access an invalid index
+        while splitViewItems.count > 1 {
+            removeSplitViewItem(splitViewItems[1])
         }
 
         // Update the reference
@@ -783,6 +782,8 @@ struct SettingsRow<Content: View>: View {
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(description != nil ? "\(title), \(description!)" : title)
     }
 }
 

--- a/AWDLControl/AWDLControl/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControl/AWDLPreferences.swift
@@ -42,8 +42,12 @@ class AWDLPreferences {
             return defaults?.bool(forKey: monitoringEnabledKey) ?? false
         }
         set {
-            defaults?.set(newValue, forKey: monitoringEnabledKey)
-            defaults?.synchronize()
+            guard let defaults = defaults else {
+                log.error("Cannot set \(monitoringEnabledKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: monitoringEnabledKey)
+            defaults.synchronize()
             // Use distributed notification for cross-process communication with widget
             DistributedNotificationCenter.default().postNotificationName(
                 .awdlMonitoringStateChanged,
@@ -60,7 +64,11 @@ class AWDLPreferences {
             return defaults?.string(forKey: lastStateKey) ?? "unknown"
         }
         set {
-            defaults?.set(newValue, forKey: lastStateKey)
+            guard let defaults = defaults else {
+                log.error("Cannot set \(lastStateKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: lastStateKey)
         }
     }
 
@@ -70,7 +78,11 @@ class AWDLPreferences {
             return defaults?.bool(forKey: controlCenterEnabledKey) ?? false
         }
         set {
-            defaults?.set(newValue, forKey: controlCenterEnabledKey)
+            guard let defaults = defaults else {
+                log.error("Cannot set \(controlCenterEnabledKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: controlCenterEnabledKey)
             NotificationCenter.default.post(name: .controlCenterModeChanged, object: nil)
         }
     }
@@ -81,7 +93,11 @@ class AWDLPreferences {
             return defaults?.bool(forKey: gameModeAutoDetectKey) ?? false
         }
         set {
-            defaults?.set(newValue, forKey: gameModeAutoDetectKey)
+            guard let defaults = defaults else {
+                log.error("Cannot set \(gameModeAutoDetectKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: gameModeAutoDetectKey)
             NotificationCenter.default.post(name: .gameModeAutoDetectChanged, object: nil)
         }
     }
@@ -92,7 +108,11 @@ class AWDLPreferences {
             return defaults?.bool(forKey: showDockIconKey) ?? false
         }
         set {
-            defaults?.set(newValue, forKey: showDockIconKey)
+            guard let defaults = defaults else {
+                log.error("Cannot set \(showDockIconKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: showDockIconKey)
             NotificationCenter.default.post(name: .dockIconVisibilityChanged, object: nil)
         }
     }

--- a/AWDLControl/AWDLControl/Info.plist
+++ b/AWDLControl/AWDLControl/Info.plist
@@ -13,9 +13,9 @@
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleVersion</key>
-    <string>2.0.0</string>
+    <string>2.0.1</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.0</string>
+    <string>2.0.1</string>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>
@@ -24,5 +24,7 @@
     <string>NSApplication</string>
     <key>LSUIElement</key>
     <true/>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2025 Oliver Ames. All rights reserved.</string>
 </dict>
 </plist>

--- a/AWDLControl/AWDLControlHelper/Info.plist
+++ b/AWDLControl/AWDLControlHelper/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleDisplayName</key>
 	<string>AWDL Control Helper</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
@@ -20,5 +20,7 @@
 	<string>AWDLControlHelper</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025 Oliver Ames. All rights reserved.</string>
 </dict>
 </plist>

--- a/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
@@ -46,8 +46,12 @@ class AWDLPreferences {
             return defaults?.bool(forKey: monitoringEnabledKey) ?? false
         }
         set {
-            defaults?.set(newValue, forKey: monitoringEnabledKey)
-            defaults?.synchronize()
+            guard let defaults = defaults else {
+                log.error("Cannot set \(monitoringEnabledKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: monitoringEnabledKey)
+            defaults.synchronize()
 
             // Use distributed notification for cross-process communication
             // NotificationCenter.default only works within the same process
@@ -66,7 +70,11 @@ class AWDLPreferences {
             return defaults?.string(forKey: lastStateKey) ?? "unknown"
         }
         set {
-            defaults?.set(newValue, forKey: lastStateKey)
+            guard let defaults = defaults else {
+                log.error("Cannot set \(lastStateKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: lastStateKey)
         }
     }
 
@@ -76,7 +84,11 @@ class AWDLPreferences {
             return defaults?.bool(forKey: controlCenterEnabledKey) ?? false
         }
         set {
-            defaults?.set(newValue, forKey: controlCenterEnabledKey)
+            guard let defaults = defaults else {
+                log.error("Cannot set \(controlCenterEnabledKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: controlCenterEnabledKey)
             // Note: Widget doesn't post this notification as it's only used by main app
         }
     }
@@ -87,7 +99,11 @@ class AWDLPreferences {
             return defaults?.bool(forKey: gameModeAutoDetectKey) ?? false
         }
         set {
-            defaults?.set(newValue, forKey: gameModeAutoDetectKey)
+            guard let defaults = defaults else {
+                log.error("Cannot set \(gameModeAutoDetectKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: gameModeAutoDetectKey)
             // Note: Widget doesn't post this notification as it's only used by main app
         }
     }
@@ -98,7 +114,11 @@ class AWDLPreferences {
             return defaults?.bool(forKey: showDockIconKey) ?? false
         }
         set {
-            defaults?.set(newValue, forKey: showDockIconKey)
+            guard let defaults = defaults else {
+                log.error("Cannot set \(showDockIconKey): defaults is nil")
+                return
+            }
+            defaults.set(newValue, forKey: showDockIconKey)
             // Note: Widget doesn't post this notification as it's only used by main app
         }
     }

--- a/AWDLControl/AWDLControlWidget/Info.plist
+++ b/AWDLControl/AWDLControlWidget/Info.plist
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDisplayName</key>
-	<string>AWDL Control</string>
+	<string>Ping Warden Widget</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025 Oliver Ames. All rights reserved.</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -13,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.0</string>
+	<string>2.0.1</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,10 @@ PROJECT_FILE="AWDLControl/AWDLControl.xcodeproj/project.pbxproj"
 # Validate team ID matches project
 echo "🔍 Validating build configuration..."
 if [ -f "$PROJECT_FILE" ]; then
-    PROJECT_TEAM=$(grep -o 'DEVELOPMENT_TEAM = [^;]*' "$PROJECT_FILE" | head -1 | cut -d'"' -f2 | tr -d '=; ')
+    # Extract DEVELOPMENT_TEAM value - handles both quoted and unquoted formats
+    # Format 1: DEVELOPMENT_TEAM = PV3W52NDZ3;
+    # Format 2: DEVELOPMENT_TEAM = "PV3W52NDZ3";
+    PROJECT_TEAM=$(grep 'DEVELOPMENT_TEAM' "$PROJECT_FILE" | grep -v '//' | head -1 | sed 's/.*DEVELOPMENT_TEAM *= *"\{0,1\}\([A-Z0-9]*\)"\{0,1\}.*/\1/')
     if [ -n "$PROJECT_TEAM" ] && [ "$PROJECT_TEAM" != "$DEVELOPMENT_TEAM" ]; then
         echo "   ⚠️  Warning: DEVELOPMENT_TEAM mismatch"
         echo "      Script: $DEVELOPMENT_TEAM"


### PR DESCRIPTION
## Code Signing & Helper Activation
- Fix XPC code signing requirement to include widget bundle ID
- Add helper bundle path validation before registration
- Add SIGTERM handler for graceful helper shutdown
- Fix version mismatch between main.m (2.0.1) and Info.plist files

## Race Conditions & Thread Safety
- Fix race condition in setAWDLEnabled dispatch_after with cancellable block
- Fix potential deadlock in exit timer handler using dispatch_async
- Fix race condition in isMonitoringActive property with proper locking
- Fix XPC invalidation handler re-entrancy with guard flag

## Memory Management & Cleanup
- Add XPC connection validation after activation
- Fix strong reference cycles in closures with [weak self]
- Add retry logic for pipe write failures (3 retries on EINTR)
- Fix semaphore handling in AWDLMonitor invalidate

## Error Handling & Validation
- Add bounds checking for routing message parsing
- Fix silent failures in AWDLPreferences with error logging
- Add proper error handling for pipe operations
- Improve error propagation to UI

## UI & Accessibility
- Add accessibility labels to SettingsRow component
- Fix CFBundleDisplayName mismatch in widget (Ping Warden Widget)
- Add NSHumanReadableCopyright to all Info.plists
- Fix splitViewItems array bounds check

## Other Fixes
- Fix build.sh DEVELOPMENT_TEAM extraction for both quoted/unquoted formats
- Sync widget AWDLPreferences with main app version
- Update all versions to 2.0.1 for consistency