### PR TITLE
fix: Address code review issues for helper activation and UserDefaults

### DIFF
--- a/AWDLControl/AWDLControl/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControl/AWDLPreferences.swift
@@ -47,7 +47,8 @@ class AWDLPreferences {
                 return
             }
             defaults.set(newValue, forKey: monitoringEnabledKey)
-            defaults.synchronize()
+            // Note: synchronize() is deprecated since macOS 10.14 - the system
+            // automatically synchronizes UserDefaults at appropriate times
             // Use distributed notification for cross-process communication with widget
             DistributedNotificationCenter.default().postNotificationName(
                 .awdlMonitoringStateChanged,

--- a/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
@@ -51,7 +51,8 @@ class AWDLPreferences {
                 return
             }
             defaults.set(newValue, forKey: monitoringEnabledKey)
-            defaults.synchronize()
+            // Note: synchronize() is deprecated since macOS 10.14 - the system
+            // automatically synchronizes UserDefaults at appropriate times
 
             // Use distributed notification for cross-process communication
             // NotificationCenter.default only works within the same process


### PR DESCRIPTION
- Remove deprecated UserDefaults.synchronize() calls in AWDLPreferences
  The system automatically synchronizes UserDefaults since macOS 10.14.
  Apple documentation states this method is "unnecessary and shouldn't be used"

- Simplify setAWDLEnabled:withReply: in helper main.m
  Changed from async dispatch_after pattern to synchronous reply.
  The previous implementation used a 10ms delay which was unnecessary
  since the property setter is synchronous. The actual interface state
  change happens asynchronously in the background monitoring thread.

These fixes improve reliability of the XPC communication and follow
Apple's current best practices for UserDefaults and XPC patterns.