### PR TITLE
fix: Address code review issues - naming, version, and unnecessary optional cast

### DIFF
--- a/AWDLControl/AWDLControl/AWDLControlApp.swift
+++ b/AWDLControl/AWDLControl/AWDLControlApp.swift
@@ -356,7 +356,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let hostingController = NSHostingController(rootView: aboutView)
 
         let window = NSWindow(contentViewController: hostingController)
-        window.title = "About AWDLControl"
+        window.title = "About Ping Warden"
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
         window.styleMask = [.titled, .closable, .fullSizeContentView]

--- a/AWDLControl/AWDLControl/AWDLMonitor.swift
+++ b/AWDLControl/AWDLControl/AWDLMonitor.swift
@@ -171,9 +171,7 @@ class AWDLMonitor {
 
     /// Validate that the helper binary and plist exist in the app bundle
     private func validateHelperBundle() -> (valid: Bool, error: String?) {
-        guard let appBundle = Bundle.main.bundlePath as String? else {
-            return (false, "Could not determine app bundle path")
-        }
+        let appBundle = Bundle.main.bundlePath
 
         let helperBinaryPath = "\(appBundle)/Contents/MacOS/AWDLControlHelper"
         let helperPlistPath = "\(appBundle)/Contents/Library/LaunchDaemons/\(helperPlistName)"

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@
 
 set -eo pipefail
 
-echo "🔨 Building Ping Warden v2.0..."
+echo "🔨 Building Ping Warden v2.0.1..."
 echo ""
 
 # Development Team ID (must match Xcode project settings)


### PR DESCRIPTION
- Fix About window title to say "About Ping Warden" instead of "About AWDLControl"
- Update build.sh version string from v2.0 to v2.0.1 to match Info.plist
- Remove unnecessary optional cast of Bundle.main.bundlePath in AWDLMonitor.swift