### PR TITLE
fix: Update copyrights to 2025-2026 and correct README settings structure

### DIFF
--- a/AWDLControl/AWDLControl/AWDLControl-Bridging-Header.h
+++ b/AWDLControl/AWDLControl/AWDLControl-Bridging-Header.h
@@ -4,7 +4,7 @@
 //
 //  Bridging header to expose Objective-C interfaces to Swift.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControl/AWDLControlApp.swift
+++ b/AWDLControl/AWDLControl/AWDLControlApp.swift
@@ -4,7 +4,7 @@
 //
 //  Main application entry point and UI for Ping Warden.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 
@@ -1288,7 +1288,7 @@ struct AboutView: View {
             }
             .padding(.vertical, 12)
 
-            Text("© 2025 Oliver Ames")
+            Text("© 2025-2026 Oliver Ames")
                 .font(.caption2)
                 .foregroundStyle(.quaternary)
                 .padding(.bottom, 16)

--- a/AWDLControl/AWDLControl/AWDLMonitor.swift
+++ b/AWDLControl/AWDLControl/AWDLMonitor.swift
@@ -4,7 +4,7 @@
 //
 //  Controls the AWDL helper daemon via SMAppService and XPC.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControl/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControl/AWDLPreferences.swift
@@ -4,7 +4,7 @@
 //
 //  Manages shared state between app and widget using App Groups.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControl/Info.plist
+++ b/AWDLControl/AWDLControl/Info.plist
@@ -25,6 +25,6 @@
     <key>LSUIElement</key>
     <true/>
     <key>NSHumanReadableCopyright</key>
-    <string>Copyright © 2025 Oliver Ames. All rights reserved.</string>
+    <string>Copyright © 2025-2026 Oliver Ames. All rights reserved.</string>
 </dict>
 </plist>

--- a/AWDLControl/AWDLControlHelper/AWDLMonitor.h
+++ b/AWDLControl/AWDLControlHelper/AWDLMonitor.h
@@ -5,7 +5,7 @@
 //  Monitors AWDL interface state using AF_ROUTE socket.
 //  Based on james-howard/AWDLControl and jamestut/awdlkiller.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControlHelper/AWDLMonitor.m
+++ b/AWDLControl/AWDLControlHelper/AWDLMonitor.m
@@ -5,7 +5,7 @@
 //  Core AWDL monitoring using AF_ROUTE socket.
 //  Based on james-howard/AWDLControl and jamestut/awdlkiller.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControlHelper/Info.plist
+++ b/AWDLControl/AWDLControlHelper/Info.plist
@@ -21,6 +21,6 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2025 Oliver Ames. All rights reserved.</string>
+	<string>Copyright © 2025-2026 Oliver Ames. All rights reserved.</string>
 </dict>
 </plist>

--- a/AWDLControl/AWDLControlHelper/com.awdlcontrol.helper.plist
+++ b/AWDLControl/AWDLControlHelper/com.awdlcontrol.helper.plist
@@ -4,7 +4,7 @@
   com.awdlcontrol.helper.plist
   SMAppService daemon configuration for AWDLControlHelper
 
-  Copyright (c) 2025 Oliver Ames. All rights reserved.
+  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
   Licensed under the MIT License.
 -->
 <plist version="1.0">

--- a/AWDLControl/AWDLControlHelper/main.m
+++ b/AWDLControl/AWDLControlHelper/main.m
@@ -6,7 +6,7 @@
 //  Registered via SMAppService, runs as LaunchDaemon.
 //  Based on james-howard/AWDLControl architecture.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControlWidget/AWDLControlWidget.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLControlWidget.swift
@@ -4,7 +4,7 @@
 //
 //  Control Center widget for toggling AWDL blocking.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
@@ -4,7 +4,7 @@
 //
 //  Manages shared state between app and widget using App Groups.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControlWidget/AWDLToggleIntent.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLToggleIntent.swift
@@ -4,7 +4,7 @@
 //
 //  App Intent to toggle AWDL monitoring from Control Center.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/AWDLControl/AWDLControlWidget/Info.plist
+++ b/AWDLControl/AWDLControlWidget/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDisplayName</key>
 	<string>Ping Warden Widget</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2025 Oliver Ames. All rights reserved.</string>
+	<string>Copyright © 2025-2026 Oliver Ames. All rights reserved.</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/AWDLControl/Common/HelperProtocol.h
+++ b/AWDLControl/Common/HelperProtocol.h
@@ -5,7 +5,7 @@
 //  XPC protocol for communication between main app and privileged helper daemon.
 //  Based on james-howard/AWDLControl SMAppService architecture.
 //
-//  Copyright (c) 2025 Oliver Ames. All rights reserved.
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 //  Licensed under the MIT License.
 //
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ Click the antenna icon in the menu bar:
 
 Access Settings from the menu bar to configure:
 
-- **General**: Enable/disable blocking, Launch at Login
-- **Advanced**: Control Center Widget (Beta), Game Mode Auto-Detect (Beta), Show Dock Icon, Diagnostics
+- **General**: Enable/disable blocking, Launch at Login, Show Dock Icon
+- **Automation**: Game Mode Auto-Detect (Beta), Control Center Widget (Beta)
+- **Advanced**: Diagnostics, Re-register Helper, Uninstall
 
 ### Control Center Widget (Beta)
 
@@ -107,6 +108,7 @@ When enabled, Ping Warden automatically activates AWDL blocking when it detects 
 ## Requirements
 
 - macOS 13.0+ (Ventura or later)
+- macOS 14.0+ (Sonoma or later) for Control Center Widget
 - Xcode 16.0+ (for building)
 
 > **Tip**: For the best app icon rendering, build from Xcode IDE rather than the command-line script. Xcode properly processes Icon Composer `.icon` files.

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 #
 # Build script for the app, widget, and helper.
 #
-# Copyright (c) 2025 Oliver Ames. All rights reserved.
+# Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 # Licensed under the MIT License.
 #
 


### PR DESCRIPTION
Changes:
- Update copyright year from 2025 to 2025-2026 across all source files
- Fix README settings section to accurately reflect UI structure:
  - General: Enable/disable blocking, Launch at Login, Show Dock Icon
  - Automation: Game Mode Auto-Detect (Beta), Control Center Widget (Beta)
  - Advanced: Diagnostics, Re-register Helper, Uninstall
- Add macOS 14.0+ requirement note for Control Center Widget in README
- Verified Icon Composer icon.json format is preserved (requires Xcode IDE)

Code review findings (no action needed):
- SMAppService + XPC architecture follows Apple best practices
- Helper daemon properly validates code signing
- Widget uses correct extension point identifier
- Entitlements correctly configured for App Groups
- Build script properly handles code signing detection