### PR TITLE
fix: Update widget requirements to macOS 26.0+ for ControlWidget support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,9 @@ jobs:
     - name: Build App (verification only)
       run: |
         echo "Building AWDLControl app..."
-        # Note: Widget is skipped in CI as it requires App Groups entitlement
-        # which needs a valid signing certificate
+        # Note: Widget is skipped in CI because:
+        # 1. It requires App Groups entitlement which needs a valid signing certificate
+        # 2. ControlWidget requires macOS 26.0+ (Tahoe) SDK for third-party Control Center controls
         xcodebuild -project AWDLControl/AWDLControl.xcodeproj \
                    -target AWDLControl \
                    -configuration Release \

--- a/AWDLControl/AWDLControl.xcodeproj/project.pbxproj
+++ b/AWDLControl/AWDLControl.xcodeproj/project.pbxproj
@@ -699,14 +699,14 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = AWDLControlWidget/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "AWDL Control";
+				INFOPLIST_KEY_CFBundleDisplayName = "Ping Warden";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.app.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -731,14 +731,14 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = AWDLControlWidget/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "AWDL Control";
+				INFOPLIST_KEY_CFBundleDisplayName = "Ping Warden";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.app.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,7 @@ NotificationCenter.default.post(name: .awdlMonitoringStateChanged, object: nil)
 ## Requirements
 
 - macOS 13.0+ (Ventura or later)
+- macOS 26.0+ (Tahoe or later) for Control Center Widget
 - Xcode 16.0+ (for building)
 
 ## Common Issues

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ When enabled, Ping Warden automatically activates AWDL blocking when it detects 
 ## Requirements
 
 - macOS 13.0+ (Ventura or later)
-- macOS 14.0+ (Sonoma or later) for Control Center Widget
+- macOS 26.0+ (Tahoe or later) for Control Center Widget
 - Xcode 16.0+ (for building)
 
 > **Tip**: For the best app icon rendering, build from Xcode IDE rather than the command-line script. Xcode properly processes Icon Composer `.icon` files.


### PR DESCRIPTION
- Update widget deployment target from 14.0 to 26.0 (Tahoe)
  Third-party Control Center controls require macOS 26.0+
- Fix widget display name from "AWDL Control" to "Ping Warden"
- Update README and CLAUDE.md documentation to reflect correct requirements
- Improve CI workflow comment explaining widget build skip reasons

Research verified:
- macOS 15 Sequoia does NOT support third-party Control Center controls
- macOS 26 Tahoe introduces third-party Control Center widget support
- Helper implementation correctly follows awdlkiller AF_ROUTE/ioctl approach