### PR TITLE
fix: Remove invalid AWDLHelper target and clarify Xcode requirements

### DIFF
--- a/AWDLControl/AWDLControl.xcodeproj/project.pbxproj
+++ b/AWDLControl/AWDLControl.xcodeproj/project.pbxproj
@@ -37,15 +37,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		81865E1C2EAEC91800AB80D3 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = /usr/share/man/man1/;
-			dstSubfolderSpec = 0;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 1;
-		};
 		WidgetEmbed /* Embed Foundation Extensions */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -60,7 +51,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		81865E1E2EAEC91800AB80D3 /* AWDLHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = AWDLHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		AppRef /* AWDLControl.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = AWDLControl.app; path = "Ping Warden.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		HelperRef /* AWDLControlHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = AWDLControlHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		SwiftUIRef /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
@@ -86,11 +76,6 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		81865E1F2EAEC91800AB80D3 /* AWDLHelper */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = AWDLHelper;
-			sourceTree = "<group>";
-		};
 		AppGroup /* AWDLControl */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -120,13 +105,6 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		81865E1B2EAEC91800AB80D3 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		AppFrameworks /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -168,7 +146,6 @@
 				AppRef /* AWDLControl.app */,
 				WidgetRef /* AWDLControlWidget.appex */,
 				HelperRef /* AWDLControlHelper */,
-				81865E1E2EAEC91800AB80D3 /* AWDLHelper */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -180,7 +157,6 @@
 				WidgetGroup /* AWDLControlWidget */,
 				HelperGroup /* AWDLControlHelper */,
 				CommonGroup /* Common */,
-				81865E1F2EAEC91800AB80D3 /* AWDLHelper */,
 				ProductsGroup /* Products */,
 				FrameworksGroup /* Frameworks */,
 			);
@@ -189,28 +165,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		81865E1D2EAEC91800AB80D3 /* AWDLHelper */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 81865E222EAEC91800AB80D3 /* Build configuration list for PBXNativeTarget "AWDLHelper" */;
-			buildPhases = (
-				81865E1A2EAEC91800AB80D3 /* Sources */,
-				81865E1B2EAEC91800AB80D3 /* Frameworks */,
-				81865E1C2EAEC91800AB80D3 /* CopyFiles */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			fileSystemSynchronizedGroups = (
-				81865E1F2EAEC91800AB80D3 /* AWDLHelper */,
-			);
-			name = AWDLHelper;
-			packageProductDependencies = (
-			);
-			productName = AWDLHelper;
-			productReference = 81865E1E2EAEC91800AB80D3 /* AWDLHelper */;
-			productType = "com.apple.product-type.tool";
-		};
 		AppTarget /* AWDLControl */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = AppConfigList /* Build configuration list for PBXNativeTarget "AWDLControl" */;
@@ -292,9 +246,6 @@
 				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
-					81865E1D2EAEC91800AB80D3 = {
-						CreatedOnToolsVersion = 26.0.1;
-					};
 					AppTarget = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -323,7 +274,6 @@
 				AppTarget /* AWDLControl */,
 				WidgetTarget /* AWDLControlWidget */,
 				HelperTarget /* AWDLControlHelper */,
-				81865E1D2EAEC91800AB80D3 /* AWDLHelper */,
 			);
 		};
 /* End PBXProject section */
@@ -381,13 +331,6 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		81865E1A2EAEC91800AB80D3 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		AppSources /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -430,38 +373,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		81865E232EAEC91800AB80D3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PV3W52NDZ3;
-				ENABLE_HARDENED_RUNTIME = YES;
-				INFOPLIST_FILE = AWDLHelper/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.helper;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Debug;
-		};
-		81865E242EAEC91800AB80D3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PV3W52NDZ3;
-				ENABLE_HARDENED_RUNTIME = YES;
-				INFOPLIST_FILE = AWDLHelper/Info.plist;
-				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.helper;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = Release;
-		};
 		AppDebugConfig /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -753,15 +664,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		81865E222EAEC91800AB80D3 /* Build configuration list for PBXNativeTarget "AWDLHelper" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				81865E232EAEC91800AB80D3 /* Debug */,
-				81865E242EAEC91800AB80D3 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		AppConfigList /* Build configuration list for PBXNativeTarget "AWDLControl" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ Or from the app: Settings → Advanced → Uninstall
 
 GitHub Actions workflow (`.github/workflows/build.yml`):
 - Runs on: `macos-14` with Xcode 16
-- Builds app, widget, and helper
+- Builds app and helper (widget skipped - requires macOS 26 SDK)
 - Verifies build artifacts exist
 
 ## Code Patterns
@@ -275,7 +275,8 @@ NotificationCenter.default.post(name: .awdlMonitoringStateChanged, object: nil)
 
 - macOS 13.0+ (Ventura or later)
 - macOS 26.0+ (Tahoe or later) for Control Center Widget
-- Xcode 16.0+ (for building)
+- Xcode 16.0+ (for building app and helper)
+- Xcode 26.0+ (for building Control Center Widget - requires macOS 26 SDK)
 
 ## Common Issues
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ When enabled, Ping Warden automatically activates AWDL blocking when it detects 
 
 - macOS 13.0+ (Ventura or later)
 - macOS 26.0+ (Tahoe or later) for Control Center Widget
-- Xcode 16.0+ (for building)
+- Xcode 16.0+ (for building app and helper)
+- Xcode 26.0+ (for building Control Center Widget - requires macOS 26 SDK)
 
 > **Tip**: For the best app icon rendering, build from Xcode IDE rather than the command-line script. Xcode properly processes Icon Composer `.icon` files.
 


### PR DESCRIPTION
- Remove orphaned AWDLHelper target from Xcode project that referenced
  non-existent AWDLHelper/Info.plist (the actual helper is AWDLControlHelper)
- Update README and CLAUDE.md to clarify Xcode version requirements:
  - Xcode 16.0+ for app and helper
  - Xcode 26.0+ for Control Center Widget (requires macOS 26 SDK)
- Fix CI/CD documentation to reflect that widget is skipped in CI
  (requires macOS 26 SDK not available on macos-14 runner)