### PR TITLE
fix: Improve signal handling safety and thread synchronization

### DIFF
--- a/FUTURE_IDEAS.md
+++ b/FUTURE_IDEAS.md
@@ -2,105 +2,56 @@
 
 This document captures ideas for future development that have been discussed but not yet implemented.
 
-## Password Prompt Reduction
+---
 
-### Current Behavior
-Password prompts (via `osascript` with `administrator privileges`) are required for:
-- **Initial install**: Writing daemon to `/usr/local/bin/` and plist to `/Library/LaunchDaemons/`
-- **Every start**: `launchctl bootstrap system/...` requires root
-- **Every stop**: `launchctl bootout system/...` requires root
-- **Reinstall/Uninstall**: Same privileged operations
+## v2.0 Implementation Complete
 
-### Mitigation (Current)
-Enabling "Launch at Login" reduces password prompts because:
-1. The daemon starts automatically at boot (LaunchDaemon)
-2. The app starts automatically at login
-3. If daemon is already running, toggling just sends signals (no launchctl needed)
-
-### Future Options Explored
-
-#### Option 1: Daemon Always Runs + IPC Control
-**Concept**: Daemon starts at boot and runs continuously. App sends enable/disable commands via Unix socket or control file instead of starting/stopping the daemon process.
-
-**Pros:**
-- Password only at initial install
-- Instant toggle response
-- Works with Control Center widget without password
-
-**Cons:**
-- Daemon uses resources even when disabled
-- More complex daemon code
-- Security: any process could send commands
-
-**Implementation**: ~2-3 hours
-- Modify daemon to watch control file + AF_ROUTE socket
-- Modify AWDLMonitor.swift to write control file
-
-#### Option 2: SMAppService Privileged Helper (XPC)
-**Concept**: Modern Apple approach using XPC for privileged operations.
-
-**Pros:**
-- Apple's recommended pattern
-- Secure (code-signed verification)
-- Password only at helper installation
-
-**Cons:**
-- Requires Developer ID code signing
-- More complex architecture
-- XPC learning curve
-
-**Implementation**: ~1-2 days
-
-#### Option 3: Control File Approach (Simplest)
-**Concept**: Daemon watches a control file (e.g., `/var/run/awdl_control`).
-
-```c
-// Daemon pseudocode
-while (1) {
-    poll(fds, 2, -1);  // AF_ROUTE + control file
-    if (control_file_changed) {
-        enabled = read_control_file();
-    }
-    if (enabled && awdl_came_up) {
-        disable_awdl();
-    }
-}
-```
-
-**Pros:**
-- Minimal daemon changes (~50 lines)
-- No code signing requirements
-- Password only at install
-
-**Cons:**
-- Control file permissions matter
-- Less secure than XPC
-
-**Implementation**: ~2-3 hours
-
-### Recommendation
-Option 3 (Control File) offers the best balance of simplicity and user experience improvement. It requires minimal C code changes and eliminates ongoing password prompts after initial setup.
+**Note**: The following options discussed in earlier versions have been implemented in v2.0:
+- **SMAppService + XPC architecture** is now the foundation of Ping Warden
+- Password prompts eliminated - only one-time system approval required
+- Helper daemon is bundled inside the app for clean uninstall
+- Helper exits when app quits, automatically restoring AWDL
 
 ---
 
-## Other Future Ideas
+## Control Center Widget Improvements
 
-### Control Center Widget Improvements
-- Investigate why widget may not appear in Control Center
-- Test on physical macOS 26 device
+- Test widget appearance on physical macOS 26 (Tahoe) device
 - Consider adding widget configuration options
+- Investigate widget state synchronization timing
 
-### Game Mode Detection Enhancements
-- Use actual macOS Game Mode API if/when available
+## Game Mode Detection Enhancements
+
+- Use actual macOS Game Mode API if/when Apple provides public APIs
 - Add configurable list of "game" applications
-- Reduce polling interval or use event-based detection
+- Reduce polling interval or use event-based detection via NSWorkspace notifications
+- Consider using CGWindowListCopyWindowInfo less frequently (every 5s instead of 2s)
 
-### UI/UX Improvements
-- Add onboarding tutorial
-- Localization support
+## UI/UX Improvements
+
+- Add onboarding tutorial for first-time users
+- Localization support (German, French, Japanese, etc.)
 - Keyboard shortcuts for common actions
-- Touch Bar support (if applicable)
+- VoiceOver accessibility improvements
+
+## Performance Optimizations
+
+- Profile helper daemon memory usage over long running periods
+- Investigate if AF_ROUTE socket filter can reduce message volume
+- Consider using dispatch_source for file descriptor monitoring instead of poll()
+
+## Security Enhancements
+
+- Add option for stricter XPC code signing requirements
+- Consider certificate pinning for release builds
+- Audit for potential TOCTOU race conditions in permission checks
+
+## Distribution
+
+- Notarize app for distribution outside Mac App Store
+- Create DMG installer with proper background image
+- Consider Homebrew Cask formula
 
 ---
 
-*Last updated: 2025*
+*Last updated: 2026*


### PR DESCRIPTION
## Changes

### Helper daemon signal handling (main.m)
- Replace traditional SIGTERM signal handler with dispatch_source
- The old approach called Objective-C methods directly in signal context,
  which is not async-signal-safe and could cause undefined behavior
- New dispatch-based approach safely handles SIGTERM on the main queue
- Graceful shutdown now properly waits for cleanup before exit

### Thread synchronization (AWDLMonitor.m)
- Replace BOOL _threadRunning with atomic_bool for thread safety
- Use atomic_load/atomic_store to prevent data races between
  main thread (invalidate/dealloc) and pollIoctl background thread
- Added <stdatomic.h> import for C11 atomic operations

### Documentation (FUTURE_IDEAS.md)
- Updated to reflect that v2.0 already implements SMAppService + XPC
- Removed outdated discussion of password prompt mitigations
- Added new future improvement ideas

## Verification

These changes follow Apple's recommended patterns from 2025/2026 documentation:
- dispatch_source for signal handling in dispatch_main() apps
- Proper thread synchronization for multi-threaded code
- NSXPCListener.activate() (macOS 13+) instead of deprecated resume()

The core AF_ROUTE monitoring logic matches jamestut/awdlkiller's approach
and the XPC architecture follows james-howard/AWDLControl patterns.