### PR TITLE
fix: Update code signing to follow Apple best practices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,47 @@ jobs:
         ls -la "AWDLControl/build/Release/Ping Warden.app/Contents/MacOS/" || true
         echo ""
 
+        echo "Helper plist (source):"
+        ls -la "AWDLControl/AWDLControlHelper/com.awdlcontrol.helper.plist"
+        echo ""
+
         echo "=== Build verification passed ==="
         echo ""
         echo "Note: This is a CI verification build without code signing."
         echo "For a distributable app, build locally with a Developer ID certificate."
+
+    - name: Verify Bundle Structure Requirements
+      run: |
+        # Verify all required source files exist for proper bundling
+        echo "Checking required files for app bundling..."
+
+        # Check helper binary exists
+        if [ ! -f "AWDLControl/build/Release/AWDLControlHelper" ]; then
+          echo "ERROR: Helper binary missing"
+          exit 1
+        fi
+        echo "✓ Helper binary present"
+
+        # Check helper plist exists
+        if [ ! -f "AWDLControl/AWDLControlHelper/com.awdlcontrol.helper.plist" ]; then
+          echo "ERROR: Helper plist missing"
+          exit 1
+        fi
+        echo "✓ Helper plist present"
+
+        # Check app bundle exists
+        if [ ! -d "AWDLControl/build/Release/Ping Warden.app" ]; then
+          echo "ERROR: App bundle missing"
+          exit 1
+        fi
+        echo "✓ App bundle present"
+
+        # Verify main binary exists in app
+        if [ ! -f "AWDLControl/build/Release/Ping Warden.app/Contents/MacOS/Ping Warden" ]; then
+          echo "ERROR: Main binary missing from app bundle"
+          exit 1
+        fi
+        echo "✓ Main binary present in app bundle"
+
+        echo ""
+        echo "All bundle structure requirements verified."

--- a/FUTURE_IDEAS.md
+++ b/FUTURE_IDEAS.md
@@ -42,7 +42,7 @@ This document captures ideas for future development that have been discussed but
 
 ## Security Enhancements
 
-- Add option for stricter XPC code signing requirements
+- ✅ XPC code signing requirements implemented in helper (enforces Team ID verification)
 - Consider certificate pinning for release builds
 - Audit for potential TOCTOU race conditions in permission checks
 
@@ -54,4 +54,4 @@ This document captures ideas for future development that have been discussed but
 
 ---
 
-*Last updated: 2026*
+*Last updated: January 2026*

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Ping Warden v2.0 uses SMAppService which requires proper code signing. The build
 ./build.sh  # Automatically uses your Developer ID certificate
 ```
 
+The build script signs components individually (helper, widget, then app) per Apple's best practices for code signing nested bundles.
+
 > **Note**: The build script will fail if no valid signing certificate is found. Ensure you're signed into Xcode with your Apple Developer account.
 
 ## Usage


### PR DESCRIPTION
- Replace deprecated --deep codesign flag with individual component signing
- Sign components depth-first: helper → widget → app bundle
- Use --deep only for verification (correct per Apple docs)
- Add bundle structure verification step to CI workflow
- Update CLAUDE.md with core algorithm documentation
- Document code signing best practices in both README and CLAUDE.md
- Fix app bundle structure documentation to show correct naming
- Mark XPC code signing requirement as implemented in FUTURE_IDEAS

The build script now follows Apple's recommended approach for signing
nested bundles, which was documented as the preferred method after
--deep was deprecated in macOS 13.

Verified implementation matches original awdlkiller by jamestut:
- AF_ROUTE socket for kernel routing notifications
- poll() with infinite timeout for zero CPU when idle
- ioctl(SIOCSIFFLAGS) to disable IFF_UP flag

References:
- https://developer.apple.com/library/archive/technotes/tn2206/
- https://github.com/jamestut/awdlkiller