### PR TITLE
fix: Add backward-compatible onChange and intervention counter reset

### DIFF
--- a/AWDLControl/.githubISSUE_TEMPLATEbug_report.md
+++ b/AWDLControl/.githubISSUE_TEMPLATEbug_report.md
@@ -1,0 +1,84 @@
+---
+name: Bug Report
+about: Report a problem with Ping Warden
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Description
+<!-- A clear description of what the bug is -->
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What you expected to happen -->
+
+## Actual Behavior
+<!-- What actually happened -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## System Information
+
+**macOS Version:**
+<!-- Run: sw_vers -->
+```
+Paste output here
+```
+
+**Ping Warden Version:**
+<!-- Found in: About Ping Warden -->
+- Version: 
+
+**Installation Method:**
+- [ ] Right-click → Open
+- [ ] install.sh script
+- [ ] Terminal xattr command
+- [ ] Other: 
+
+## Diagnostic Information
+
+**Helper Status:**
+<!-- Settings → General → Status -->
+- Status: 
+
+**Helper Registration:**
+<!-- Settings → Advanced or run: ps aux | grep AWDLControlHelper -->
+- [ ] Helper is registered
+- [ ] Helper is running
+- [ ] Helper is not registered
+- [ ] Unknown
+
+**AWDL Interface:**
+<!-- Run: ifconfig awdl0 -->
+```
+Paste output here (first 2-3 lines)
+```
+
+**Console Logs:**
+<!-- Open Console.app, filter by "awdlcontrol", export recent logs -->
+```
+Paste relevant error messages here
+```
+
+## Additional Context
+<!-- Any other information that might be helpful -->
+
+## Troubleshooting Steps Tried
+<!-- Check all that apply -->
+- [ ] Restarted the app
+- [ ] Re-registered helper (Settings → Advanced)
+- [ ] Checked System Settings → Login Items
+- [ ] Removed quarantine flag (xattr -cr)
+- [ ] Reinstalled the app
+- [ ] Checked Console.app for errors
+- [ ] Other: 
+
+---
+
+**Before submitting:** Please check [TROUBLESHOOTING.md](../TROUBLESHOOTING.md) for common issues and solutions.

--- a/AWDLControl/.githubISSUE_TEMPLATEfeature_request.md
+++ b/AWDLControl/.githubISSUE_TEMPLATEfeature_request.md
@@ -1,0 +1,37 @@
+---
+name: Feature Request
+about: Suggest an idea for Ping Warden
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+<!-- A clear description of the feature you'd like to see -->
+
+## Use Case
+<!-- Why would this feature be useful? What problem does it solve? -->
+
+## Proposed Solution
+<!-- How do you think this should work? -->
+
+## Alternatives Considered
+<!-- Are there any alternative solutions or workarounds? -->
+
+## Additional Context
+<!-- Any other information, mockups, or examples -->
+
+## Impact
+<!-- How many users would benefit from this? -->
+- [ ] All users
+- [ ] Power users
+- [ ] Gamers
+- [ ] Developers
+- [ ] Specific use case: 
+
+## Implementation Complexity
+<!-- If you have technical knowledge, estimate the difficulty -->
+- [ ] Simple (UI change, preference toggle)
+- [ ] Moderate (new feature, requires some refactoring)
+- [ ] Complex (architectural changes, new dependencies)
+- [ ] Unknown

--- a/AWDLControl/AWDLControl.xcodeproj/project.pbxproj
+++ b/AWDLControl/AWDLControl.xcodeproj/project.pbxproj
@@ -44,7 +44,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		AppRef /* AWDLControl.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; name = AWDLControl.app; path = "Ping Warden.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		81A89CFF2F34EADE00B4745F /* install.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = install.sh; sourceTree = "<group>"; };
+		81A89D002F34EB0A00B4745F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		81A89D012F34EB2A00B4745F /* create-dmg.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "create-dmg.sh"; sourceTree = "<group>"; };
+		81A89D022F34EB6100B4745F /* TROUBLESHOOTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = TROUBLESHOOTING.md; sourceTree = "<group>"; };
+		81A89D032F34EB6F00B4745F /* .githubISSUE_TEMPLATEbug_report.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = .githubISSUE_TEMPLATEbug_report.md; sourceTree = "<group>"; };
+		81A89D042F34EB7700B4745F /* .githubISSUE_TEMPLATEfeature_request.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = .githubISSUE_TEMPLATEfeature_request.md; sourceTree = "<group>"; };
+		81A89D052F34EB8C00B4745F /* QUICKSTART.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = QUICKSTART.md; sourceTree = "<group>"; };
+		AppRef /* Ping Warden.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Ping Warden.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		HelperRef /* AWDLControlHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = AWDLControlHelper; sourceTree = BUILT_PRODUCTS_DIR; };
 		SwiftUIRef /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		WidgetKitRef /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
@@ -136,7 +143,7 @@
 		ProductsGroup /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				AppRef /* AWDLControl.app */,
+				AppRef /* Ping Warden.app */,
 				WidgetRef /* AWDLControlWidget.appex */,
 				HelperRef /* AWDLControlHelper */,
 			);
@@ -152,6 +159,13 @@
 				CommonGroup /* Common */,
 				ProductsGroup /* Products */,
 				FrameworksGroup /* Frameworks */,
+				81A89CFF2F34EADE00B4745F /* install.sh */,
+				81A89D002F34EB0A00B4745F /* README.md */,
+				81A89D012F34EB2A00B4745F /* create-dmg.sh */,
+				81A89D022F34EB6100B4745F /* TROUBLESHOOTING.md */,
+				81A89D032F34EB6F00B4745F /* .githubISSUE_TEMPLATEbug_report.md */,
+				81A89D042F34EB7700B4745F /* .githubISSUE_TEMPLATEfeature_request.md */,
+				81A89D052F34EB8C00B4745F /* QUICKSTART.md */,
 			);
 			sourceTree = "<group>";
 		};
@@ -182,7 +196,7 @@
 			packageProductDependencies = (
 			);
 			productName = AWDLControl;
-			productReference = AppRef /* AWDLControl.app */;
+			productReference = AppRef /* Ping Warden.app */;
 			productType = "com.apple.product-type.application";
 		};
 		HelperTarget /* AWDLControlHelper */ = {
@@ -311,15 +325,15 @@
 			files = (
 			);
 			inputPaths = (
-				"$(SRCROOT)/AWDLControlHelper/com.awdlcontrol.helper.plist",
+				"$(​SRCROOT)/​AWDLControl​Helper​/com​.amesvt​.pingwarden​.helper​.plist",
 			);
 			name = "Copy Helper Plist";
 			outputPaths = (
-				"$(BUILT_PRODUCTS_DIR)/$(CONTENTS_FOLDER_PATH)/Library/LaunchDaemons/com.awdlcontrol.helper.plist",
+				"$(​BUILT​_​PRODUCTS​_​DIR)/$(​CONTENTS​_​FOLDER​_​PATH)/​Library​/​Launch​Daemons​/com​.amesvt​.pingwarden​.helper​.plist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchDaemons\"\ncp \"${SRCROOT}/AWDLControlHelper/com.awdlcontrol.helper.plist\" \"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchDaemons/\"\n";
+			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchDaemons\"\n   cp \"${SRCROOT}/AWDLControlHelper/com.amesvt.pingwarden.helper.plist\" \"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Library/LaunchDaemons/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -366,12 +380,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = AWDLControl/AWDLControl.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PV3W52NDZ3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PV3W52NDZ3;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -386,8 +402,9 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 2.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden;
 				PRODUCT_NAME = "Ping Warden";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -401,12 +418,14 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = AWDLControl/AWDLControl.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PV3W52NDZ3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PV3W52NDZ3;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -421,8 +440,9 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 2.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.app;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden;
 				PRODUCT_NAME = "Ping Warden";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -434,16 +454,18 @@
 		HelperDebugConfig /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PV3W52NDZ3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PV3W52NDZ3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = AWDLControlHelper/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.helper;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden.helper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -451,16 +473,18 @@
 		HelperReleaseConfig /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				CREATE_INFOPLIST_SECTION_IN_BINARY = YES;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PV3W52NDZ3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PV3W52NDZ3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = AWDLControlHelper/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.helper;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden.helper;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -504,7 +528,7 @@
 				DEVELOPMENT_TEAM = PV3W52NDZ3;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -568,7 +592,7 @@
 				DEVELOPMENT_TEAM = PV3W52NDZ3;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -591,10 +615,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = AWDLControlWidget/AWDLControlWidget.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PV3W52NDZ3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PV3W52NDZ3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = AWDLControlWidget/Info.plist;
@@ -607,8 +633,9 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.app.widget;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
@@ -623,10 +650,12 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_ENTITLEMENTS = AWDLControlWidget/AWDLControlWidget.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_TEAM = PV3W52NDZ3;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = PV3W52NDZ3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = AWDLControlWidget/Info.plist;
@@ -639,8 +668,9 @@
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
 				MARKETING_VERSION = 2.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.awdlcontrol.app.widget;
+				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;

--- a/AWDLControl/AWDLControl/AWDLControl.entitlements
+++ b/AWDLControl/AWDLControl/AWDLControl.entitlements
@@ -4,9 +4,5 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.awdlcontrol.app</string>
-	</array>
 </dict>
 </plist>

--- a/AWDLControl/AWDLControl/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControl/AWDLPreferences.swift
@@ -11,13 +11,13 @@
 import Foundation
 import os.log
 
-private let log = Logger(subsystem: "com.awdlcontrol.app", category: "Preferences")
+private let log = Logger(subsystem: "com.amesvt.pingwarden", category: "Preferences")
 
 /// Manages shared state between app and widget using App Groups
 class AWDLPreferences {
     static let shared = AWDLPreferences()
 
-    private let appGroupID = "group.com.awdlcontrol.app"
+    private let appGroupID = "group.com.amesvt.pingwarden"
     private let monitoringEnabledKey = "AWDLMonitoringEnabled"
     private let lastStateKey = "AWDLLastState"
     private let controlCenterEnabledKey = "ControlCenterWidgetEnabled"
@@ -121,8 +121,8 @@ class AWDLPreferences {
 
 extension Notification.Name {
     // Use namespaced notification names to avoid collisions with other apps
-    static let awdlMonitoringStateChanged = Notification.Name("com.awdlcontrol.notification.MonitoringStateChanged")
-    static let controlCenterModeChanged = Notification.Name("com.awdlcontrol.notification.ControlCenterModeChanged")
-    static let gameModeAutoDetectChanged = Notification.Name("com.awdlcontrol.notification.GameModeAutoDetectChanged")
-    static let dockIconVisibilityChanged = Notification.Name("com.awdlcontrol.notification.DockIconVisibilityChanged")
+    static let awdlMonitoringStateChanged = Notification.Name("com.amesvt.pingwarden.notification.MonitoringStateChanged")
+    static let controlCenterModeChanged = Notification.Name("com.amesvt.pingwarden.notification.ControlCenterModeChanged")
+    static let gameModeAutoDetectChanged = Notification.Name("com.amesvt.pingwarden.notification.GameModeAutoDetectChanged")
+    static let dockIconVisibilityChanged = Notification.Name("com.amesvt.pingwarden.notification.DockIconVisibilityChanged")
 }

--- a/AWDLControl/AWDLControl/DashboardView.swift
+++ b/AWDLControl/AWDLControl/DashboardView.swift
@@ -1,0 +1,467 @@
+//
+//  DashboardView.swift
+//  AWDLControl
+//
+//  Network quality dashboard for cloud gaming.
+//  Shows real-time ping, graphs, and AWDL intervention stats.
+//
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import SwiftUI
+import Charts
+
+// MARK: - Dashboard Settings Content
+
+struct DashboardSettingsContent: View {
+    @StateObject private var viewModel = DashboardViewModel()
+    
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                // Current Status Card
+                StatusCard(viewModel: viewModel)
+                
+                // Ping Graph
+                PingGraphCard(viewModel: viewModel)
+                
+                // AWDL Interventions Card
+                InterventionsCard(viewModel: viewModel)
+                
+                // Server Selection
+                ServerSelectionCard(viewModel: viewModel)
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(nsColor: .windowBackgroundColor))
+        .onAppear {
+            viewModel.start()
+        }
+        .onDisappear {
+            viewModel.stop()
+        }
+    }
+}
+
+// MARK: - Status Card
+
+struct StatusCard: View {
+    @ObservedObject var viewModel: DashboardViewModel
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Network Quality")
+                .font(.title2)
+                .fontWeight(.semibold)
+            
+            HStack(spacing: 30) {
+                // Current Ping
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Current Ping")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    HStack(alignment: .firstTextBaseline, spacing: 4) {
+                        Text(String(format: "%.0f", viewModel.stats.currentPing))
+                            .font(.system(size: 36, weight: .bold))
+                            .foregroundStyle(colorForQuality(viewModel.stats.quality))
+                        Text("ms")
+                            .font(.title3)
+                            .foregroundStyle(.secondary)
+                    }
+                    
+                    Label(viewModel.stats.qualityDescription, systemImage: qualityIcon(viewModel.stats.quality))
+                        .font(.caption)
+                        .foregroundStyle(colorForQuality(viewModel.stats.quality))
+                }
+                
+                Divider()
+                
+                // Stats Grid
+                VStack(alignment: .leading, spacing: 12) {
+                    StatRow(label: "Average", value: String(format: "%.0f ms", viewModel.stats.averagePing))
+                    StatRow(label: "Best", value: String(format: "%.0f ms", viewModel.stats.minimumPing))
+                    StatRow(label: "Worst", value: String(format: "%.0f ms", viewModel.stats.maximumPing))
+                }
+                
+                Divider()
+                
+                VStack(alignment: .leading, spacing: 12) {
+                    StatRow(label: "Jitter", value: String(format: "%.1f ms", viewModel.stats.jitter))
+                    StatRow(label: "Packet Loss", value: String(format: "%.1f%%", viewModel.stats.packetLoss))
+                    StatRow(label: "AWDL Status", value: viewModel.isAWDLBlocking ? "Blocking" : "Allowed", 
+                           valueColor: viewModel.isAWDLBlocking ? .green : .orange)
+                }
+            }
+        }
+        .padding(20)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+    
+    private func colorForQuality(_ quality: PingMonitor.Quality) -> Color {
+        switch quality {
+        case .excellent: return .green
+        case .good: return .yellow
+        case .fair: return .orange
+        case .poor: return .red
+        }
+    }
+    
+    private func qualityIcon(_ quality: PingMonitor.Quality) -> String {
+        switch quality {
+        case .excellent: return "checkmark.circle.fill"
+        case .good: return "checkmark.circle"
+        case .fair: return "exclamationmark.triangle"
+        case .poor: return "xmark.circle.fill"
+        }
+    }
+}
+
+struct StatRow: View {
+    let label: String
+    let value: String
+    var valueColor: Color = .primary
+    
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Text(value)
+                .font(.callout)
+                .fontWeight(.medium)
+                .foregroundStyle(valueColor)
+        }
+        .frame(width: 150)
+    }
+}
+
+// MARK: - Ping Graph Card
+
+struct PingGraphCard: View {
+    @ObservedObject var viewModel: DashboardViewModel
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                Text("Ping History")
+                    .font(.headline)
+                
+                Spacer()
+                
+                Picker("Timeframe", selection: $viewModel.selectedTimeframe) {
+                    Text("5 min").tag(5)
+                    Text("15 min").tag(15)
+                    Text("30 min").tag(30)
+                    Text("1 hour").tag(60)
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 280)
+            }
+            
+            if viewModel.pingHistory.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "chart.xyaxis.line")
+                        .font(.system(size: 48))
+                        .foregroundStyle(.tertiary)
+                    Text("Collecting ping data...")
+                        .foregroundStyle(.secondary)
+                }
+                .frame(height: 200)
+                .frame(maxWidth: .infinity)
+            } else {
+                Chart(viewModel.pingHistory) { dataPoint in
+                    LineMark(
+                        x: .value("Time", dataPoint.timestamp),
+                        y: .value("Ping", dataPoint.latencyMs)
+                    )
+                    .foregroundStyle(colorForLatency(dataPoint.latencyMs))
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+                    
+                    AreaMark(
+                        x: .value("Time", dataPoint.timestamp),
+                        y: .value("Ping", dataPoint.latencyMs)
+                    )
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [colorForLatency(dataPoint.latencyMs).opacity(0.3), .clear],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                }
+                .chartYScale(domain: 0...max(100, viewModel.maxPingInView))
+                .chartXAxis {
+                    AxisMarks(values: .automatic(desiredCount: 6)) { value in
+                        AxisGridLine()
+                        AxisTick()
+                        if let date = value.as(Date.self) {
+                            AxisValueLabel {
+                                Text(date, format: .dateTime.hour().minute())
+                                    .font(.caption2)
+                            }
+                        }
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        AxisGridLine()
+                        AxisTick()
+                        AxisValueLabel {
+                            if let intValue = value.as(Int.self) {
+                                Text("\(intValue) ms")
+                                    .font(.caption2)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 200)
+            }
+            
+            // Legend
+            HStack(spacing: 20) {
+                LegendItem(color: .green, label: "Excellent", range: "<20ms")
+                LegendItem(color: .yellow, label: "Good", range: "20-50ms")
+                LegendItem(color: .orange, label: "Fair", range: "50-100ms")
+                LegendItem(color: .red, label: "Poor", range: ">100ms")
+            }
+            .font(.caption)
+        }
+        .padding(20)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+    
+    private func colorForLatency(_ latency: Double) -> Color {
+        if latency < 20 { return .green }
+        if latency < 50 { return .yellow }
+        if latency < 100 { return .orange }
+        return .red
+    }
+}
+
+struct LegendItem: View {
+    let color: Color
+    let label: String
+    let range: String
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+            Text("\(label) (\(range))")
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+// MARK: - Interventions Card
+
+struct InterventionsCard: View {
+    @ObservedObject var viewModel: DashboardViewModel
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("AWDL Protection")
+                .font(.headline)
+            
+            HStack(spacing: 40) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Interventions Today")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text("\(viewModel.interventionCount)")
+                            .font(.system(size: 48, weight: .bold))
+                            .foregroundStyle(.green)
+                        
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("lag spikes")
+                            Text("prevented")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                }
+                
+                Spacer()
+                
+                if viewModel.interventionCount > 0 {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Label("AWDL tried to activate", systemImage: "exclamationmark.triangle.fill")
+                            .font(.subheadline)
+                            .foregroundStyle(.orange)
+                        
+                        Text("Ping Warden blocked it \(viewModel.interventionCount) times to keep your connection stable.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(12)
+                    .background(Color.orange.opacity(0.1))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+        }
+        .padding(20)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Server Selection Card
+
+struct ServerSelectionCard: View {
+    @ObservedObject var viewModel: DashboardViewModel
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Settings")
+                .font(.headline)
+            
+            HStack(spacing: 20) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Ping Server")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    
+                    Picker("Server", selection: $viewModel.selectedServer) {
+                        Text("Google DNS (Global)").tag("8.8.8.8")
+                        Text("Cloudflare (Global)").tag("1.1.1.1")
+                        Text("GeForce NOW (US West)").tag("gfn-us-west.nvidia.com")
+                        Text("GeForce NOW (US East)").tag("gfn-us-east.nvidia.com")
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 250)
+                }
+                
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Update Interval")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    
+                    Picker("Interval", selection: $viewModel.updateInterval) {
+                        Text("1 second").tag(1.0)
+                        Text("2 seconds").tag(2.0)
+                        Text("5 seconds").tag(5.0)
+                        Text("10 seconds").tag(10.0)
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 150)
+                }
+            }
+        }
+        .padding(20)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+}
+
+// MARK: - Dashboard ViewModel
+
+@MainActor
+class DashboardViewModel: ObservableObject {
+    @Published var stats = NetworkStatistics(
+        currentPing: 0,
+        averagePing: 0,
+        minimumPing: 0,
+        maximumPing: 0,
+        jitter: 0,
+        packetLoss: 0,
+        quality: .poor
+    )
+    
+    @Published var pingHistory: [PingMonitor.PingResult] = []
+    @Published var interventionCount: Int = 0
+    @Published var isAWDLBlocking: Bool = false
+    @Published var selectedTimeframe: Int = 15 // minutes
+    @Published var selectedServer: String = "8.8.8.8" {
+        didSet {
+            if selectedServer != oldValue {
+                restartMonitoring()
+            }
+        }
+    }
+    @Published var updateInterval: TimeInterval = 2.0 {
+        didSet {
+            if updateInterval != oldValue {
+                restartMonitoring()
+            }
+        }
+    }
+    
+    private let pingMonitor = PingMonitor()
+    private var interventionTimer: Timer?
+    
+    var maxPingInView: Double {
+        let filtered = pingHistory.suffix(selectedTimeframe * 30) // Approximate data points
+        return filtered.map(\.latencyMs).max() ?? 100
+    }
+    
+    func start() {
+        // Start ping monitoring
+        pingMonitor.onPingResult = { [weak self] result in
+            Task { @MainActor in
+                self?.handlePingResult(result)
+            }
+        }
+        
+        pingMonitor.onStatsUpdate = { [weak self] stats in
+            Task { @MainActor in
+                self?.stats = stats
+            }
+        }
+        
+        pingMonitor.start(server: selectedServer, interval: updateInterval)
+        
+        // Update AWDL status
+        updateAWDLStatus()
+        
+        // Start intervention counter updates
+        updateInterventionCount()
+        interventionTimer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.updateInterventionCount()
+                self?.updateAWDLStatus()
+            }
+        }
+    }
+    
+    func stop() {
+        pingMonitor.stop()
+        interventionTimer?.invalidate()
+        interventionTimer = nil
+    }
+    
+    private func restartMonitoring() {
+        pingMonitor.stop()
+        pingMonitor.clearHistory()
+        pingHistory.removeAll()
+        pingMonitor.start(server: selectedServer, interval: updateInterval)
+    }
+    
+    private func handlePingResult(_ result: PingMonitor.PingResult) {
+        pingHistory.append(result)
+        
+        // Keep only data for selected timeframe plus a bit extra
+        let cutoff = Date().addingTimeInterval(-TimeInterval(selectedTimeframe * 60 + 300))
+        pingHistory.removeAll { $0.timestamp < cutoff }
+    }
+    
+    private func updateInterventionCount() {
+        AWDLMonitor.shared.getInterventionCount { [weak self] count in
+            Task { @MainActor in
+                self?.interventionCount = count
+            }
+        }
+    }
+    
+    private func updateAWDLStatus() {
+        isAWDLBlocking = AWDLMonitor.shared.isMonitoringActive
+    }
+}

--- a/AWDLControl/AWDLControl/Info.plist
+++ b/AWDLControl/AWDLControl/Info.plist
@@ -2,29 +2,29 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>CFBundleIdentifier</key>
-    <string>com.awdlcontrol.app</string>
-    <key>CFBundleInfoDictionaryVersion</key>
-    <string>6.0</string>
-    <key>CFBundleName</key>
-    <string>Ping Warden</string>
-    <key>CFBundleDisplayName</key>
-    <string>Ping Warden</string>
-    <key>CFBundleExecutable</key>
-    <string>$(EXECUTABLE_NAME)</string>
-    <key>CFBundleVersion</key>
-    <string>2.0.1</string>
-    <key>CFBundleShortVersionString</key>
-    <string>2.0.1</string>
-    <key>CFBundlePackageType</key>
-    <string>APPL</string>
-    <key>LSMinimumSystemVersion</key>
-    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
-    <key>NSPrincipalClass</key>
-    <string>NSApplication</string>
-    <key>LSUIElement</key>
-    <true/>
-    <key>NSHumanReadableCopyright</key>
-    <string>Copyright © 2025-2026 Oliver Ames. All rights reserved.</string>
+	<key>CFBundleDisplayName</key>
+	<string>Ping Warden</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Ping Warden</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.0.1</string>
+	<key>CFBundleVersion</key>
+	<string>2.0.1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025-2026 Oliver Ames. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
 </dict>
 </plist>

--- a/AWDLControl/AWDLControl/PingMonitor.swift
+++ b/AWDLControl/AWDLControl/PingMonitor.swift
@@ -1,0 +1,362 @@
+//
+//  PingMonitor.swift
+//  AWDLControl
+//
+//  Real-time network latency monitoring for cloud gaming.
+//  Uses TCP connection timing as a proxy for ICMP ping.
+//
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import os.log
+
+private let log = Logger(subsystem: "com.amesvt.pingwarden", category: "PingMonitor")
+
+/// Monitors network latency in real-time using TCP connection timing
+/// Designed for cloud gaming - shows current ping, jitter, packet loss
+class PingMonitor {
+    
+    // MARK: - Types
+    
+    struct PingResult: Identifiable {
+        let id = UUID()
+        let latency: TimeInterval  // in seconds
+        let timestamp: Date
+        let success: Bool
+        
+        var latencyMs: Double {
+            latency * 1000.0
+        }
+    }
+    
+    enum Quality {
+        case excellent  // <20ms
+        case good       // 20-50ms
+        case fair       // 50-100ms
+        case poor       // >100ms or packet loss
+        
+        var color: String {
+            switch self {
+            case .excellent: return "green"
+            case .good: return "yellow"
+            case .fair: return "orange"
+            case .poor: return "red"
+            }
+        }
+        
+        var description: String {
+            switch self {
+            case .excellent: return "Excellent"
+            case .good: return "Good"
+            case .fair: return "Fair"
+            case .poor: return "Poor"
+            }
+        }
+    }
+    
+    // MARK: - Properties
+    
+    private var timer: Timer?
+    private var history: [PingResult] = []
+    private let maxHistorySize = 720 // 1 hour at 5-second intervals
+    private let queue = DispatchQueue(label: "com.amesvt.pingwarden.pingmonitor", qos: .utility)
+    
+    /// Current server to ping
+    var server: String = "8.8.8.8"
+    
+    /// Port to use for TCP ping (80 = HTTP, usually open)
+    var port: UInt16 = 80
+    
+    /// Interval between pings (in seconds)
+    var interval: TimeInterval = 2.0
+    
+    /// Callback when new ping result is available
+    var onPingResult: ((PingResult) -> Void)?
+    
+    /// Callback when statistics are updated
+    var onStatsUpdate: ((NetworkStatistics) -> Void)?
+    
+    // MARK: - Computed Properties
+    
+    var isMonitoring: Bool {
+        return timer != nil
+    }
+    
+    var currentPing: TimeInterval? {
+        history.last?.latency
+    }
+    
+    var currentPingMs: Double? {
+        currentPing.map { $0 * 1000.0 }
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Start monitoring with specified server and interval
+    func start(server: String? = nil, port: UInt16? = nil, interval: TimeInterval? = nil) {
+        if let server = server { self.server = server }
+        if let port = port { self.port = port }
+        if let interval = interval { self.interval = interval }
+        
+        guard !isMonitoring else {
+            log.warning("Ping monitor already running")
+            return
+        }
+        
+        log.info("Starting ping monitor: \(self.server):\(self.port) every \(self.interval)s")
+        
+        // Perform immediate ping
+        performPing()
+        
+        // Schedule repeating timer on main thread
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.timer = Timer.scheduledTimer(withTimeInterval: self.interval, repeats: true) { [weak self] _ in
+                self?.performPing()
+            }
+            // Ensure timer continues during UI interactions
+            RunLoop.main.add(self.timer!, forMode: .common)
+        }
+    }
+    
+    /// Stop monitoring
+    func stop() {
+        log.info("Stopping ping monitor")
+        
+        DispatchQueue.main.async { [weak self] in
+            self?.timer?.invalidate()
+            self?.timer = nil
+        }
+    }
+    
+    /// Get current network statistics
+    func getStatistics() -> NetworkStatistics {
+        let recentResults = Array(history.suffix(60)) // Last 2 minutes
+        
+        guard !recentResults.isEmpty else {
+            return NetworkStatistics(
+                currentPing: 0,
+                averagePing: 0,
+                minimumPing: 0,
+                maximumPing: 0,
+                jitter: 0,
+                packetLoss: 0,
+                quality: .poor
+            )
+        }
+        
+        let successfulPings = recentResults.filter { $0.success }
+        let latencies = successfulPings.map { $0.latencyMs }
+        
+        let current = recentResults.last?.latencyMs ?? 0
+        let average = latencies.isEmpty ? 0 : latencies.reduce(0, +) / Double(latencies.count)
+        let minimum = latencies.min() ?? 0
+        let maximum = latencies.max() ?? 0
+        
+        // Calculate jitter (variance in latency)
+        let jitter: Double
+        if latencies.count > 1 {
+            let diffs = zip(latencies.dropLast(), latencies.dropFirst()).map { abs($0.1 - $0.0) }
+            jitter = diffs.reduce(0, +) / Double(diffs.count)
+        } else {
+            jitter = 0
+        }
+        
+        // Calculate packet loss
+        let totalPings = recentResults.count
+        let failedPings = recentResults.filter { !$0.success }.count
+        let packetLoss = totalPings > 0 ? (Double(failedPings) / Double(totalPings)) * 100.0 : 0
+        
+        // Determine quality
+        let quality: Quality
+        if current < 20 && packetLoss < 1.0 {
+            quality = .excellent
+        } else if current < 50 && packetLoss < 2.0 {
+            quality = .good
+        } else if current < 100 && packetLoss < 5.0 {
+            quality = .fair
+        } else {
+            quality = .poor
+        }
+        
+        return NetworkStatistics(
+            currentPing: current,
+            averagePing: average,
+            minimumPing: minimum,
+            maximumPing: maximum,
+            jitter: jitter,
+            packetLoss: packetLoss,
+            quality: quality
+        )
+    }
+    
+    /// Get historical ping data for graphing
+    func getHistory(lastMinutes: Int = 60) -> [PingResult] {
+        let cutoff = Date().addingTimeInterval(-TimeInterval(lastMinutes * 60))
+        return history.filter { $0.timestamp > cutoff }
+    }
+    
+    /// Clear history
+    func clearHistory() {
+        history.removeAll()
+    }
+    
+    // MARK: - Private Methods
+    
+    private func performPing() {
+        let startTime = Date()
+        
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            
+            // Perform TCP connection timing
+            let success = self.tcpPing(host: self.server, port: self.port)
+            let endTime = Date()
+            let latency = endTime.timeIntervalSince(startTime)
+            
+            let result = PingResult(
+                latency: latency,
+                timestamp: endTime,
+                success: success
+            )
+            
+            // Store in history
+            self.addToHistory(result)
+            
+            // Notify callbacks on main thread
+            DispatchQueue.main.async {
+                self.onPingResult?(result)
+                self.onStatsUpdate?(self.getStatistics())
+            }
+            
+            if success {
+                log.debug("Ping to \(self.server): \(String(format: "%.1f", result.latencyMs))ms")
+            } else {
+                log.warning("Ping to \(self.server) failed")
+            }
+        }
+    }
+    
+    private func addToHistory(_ result: PingResult) {
+        history.append(result)
+        
+        // Trim history if it gets too large
+        if history.count > maxHistorySize {
+            history.removeFirst(history.count - maxHistorySize)
+        }
+    }
+    
+    /// Perform TCP connection timing (proxy for ICMP ping)
+    /// Returns true if connection succeeded (regardless of actual latency)
+    private func tcpPing(host: String, port: UInt16) -> Bool {
+        var hints = addrinfo(
+            ai_flags: AI_NUMERICSERV,
+            ai_family: AF_UNSPEC,
+            ai_socktype: SOCK_STREAM,
+            ai_protocol: IPPROTO_TCP,
+            ai_addrlen: 0,
+            ai_canonname: nil,
+            ai_addr: nil,
+            ai_next: nil
+        )
+        
+        var result: UnsafeMutablePointer<addrinfo>?
+        let status = getaddrinfo(host, String(port), &hints, &result)
+        
+        guard status == 0, let addrInfo = result else {
+            if let result = result {
+                freeaddrinfo(result)
+            }
+            return false
+        }
+        
+        defer { freeaddrinfo(result) }
+        
+        // Create socket
+        let sock = socket(addrInfo.pointee.ai_family, addrInfo.pointee.ai_socktype, addrInfo.pointee.ai_protocol)
+        guard sock >= 0 else {
+            return false
+        }
+        
+        defer { close(sock) }
+        
+        // Set non-blocking
+        let flags = fcntl(sock, F_GETFL, 0)
+        _ = fcntl(sock, F_SETFL, flags | O_NONBLOCK)
+        
+        // Attempt connection
+        let connectResult = Darwin.connect(sock, addrInfo.pointee.ai_addr, addrInfo.pointee.ai_addrlen)
+        
+        if connectResult == 0 {
+            // Connected immediately (unlikely but possible)
+            return true
+        }
+        
+        if errno != EINPROGRESS {
+            // Connection failed
+            return false
+        }
+        
+        // Wait for connection with timeout (2 seconds)
+        var readfds = fd_set()
+        var writefds = fd_set()
+        fdZero(&readfds)
+        fdZero(&writefds)
+        fdSet(sock, set: &writefds)
+        
+        var timeout = timeval(tv_sec: 2, tv_usec: 0)
+        let selectResult = select(sock + 1, &readfds, &writefds, nil, &timeout)
+        
+        if selectResult <= 0 {
+            // Timeout or error
+            return false
+        }
+        
+        // Check if connection succeeded
+        var error: Int32 = 0
+        var errorLen = socklen_t(MemoryLayout<Int32>.size)
+        getsockopt(sock, SOL_SOCKET, SO_ERROR, &error, &errorLen)
+        
+        return error == 0
+    }
+    
+    // MARK: - fd_set Helpers
+    
+    private func fdZero(_ set: inout fd_set) {
+        set = fd_set()
+    }
+    
+    private func fdSet(_ fd: Int32, set: inout fd_set) {
+        // fd_set on Darwin uses fds_bits as a tuple of Int32 values
+        // Each Int32 holds 32 file descriptors as bits
+        let intOffset = Int(fd / 32)
+        let bitOffset = Int(fd % 32)
+        
+        withUnsafeMutableBytes(of: &set.fds_bits) { rawPtr in
+            let ptr = rawPtr.baseAddress!.assumingMemoryBound(to: Int32.self)
+            ptr[intOffset] |= Int32(1 << bitOffset)
+        }
+    }
+}
+
+// MARK: - Network Statistics
+
+struct NetworkStatistics {
+    let currentPing: Double      // milliseconds
+    let averagePing: Double      // milliseconds
+    let minimumPing: Double      // milliseconds
+    let maximumPing: Double      // milliseconds
+    let jitter: Double           // milliseconds (variance)
+    let packetLoss: Double       // percentage (0-100)
+    let quality: PingMonitor.Quality
+    
+    var qualityColor: String {
+        quality.color
+    }
+    
+    var qualityDescription: String {
+        quality.description
+    }
+}

--- a/AWDLControl/AWDLControl/QuarantineHelper.swift
+++ b/AWDLControl/AWDLControl/QuarantineHelper.swift
@@ -1,0 +1,122 @@
+//
+//  QuarantineHelper.swift
+//  AWDLControl
+//
+//  Helper to check if the app was downloaded and needs quarantine removal.
+//  Provides user guidance for Gatekeeper issues.
+//
+//  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
+//  Licensed under the MIT License.
+//
+
+import Foundation
+import AppKit
+
+/// Utility to detect and help resolve Gatekeeper quarantine issues
+struct QuarantineHelper {
+    
+    /// Check if the app bundle has quarantine attributes
+    static func isQuarantined() -> Bool {
+        guard let bundlePath = Bundle.main.bundlePath as NSString? else {
+            return false
+        }
+        
+        // Try to get quarantine xattr
+        let path = bundlePath.utf8String!
+        let attrName = "com.apple.quarantine"
+        
+        // Get size of attribute
+        let size = Darwin.getxattr(path, attrName, nil, 0, 0, 0)
+        
+        // If size > 0, quarantine attribute exists
+        return size > 0
+    }
+    
+    /// Check if the app is code signed (not ad-hoc)
+    static func isProperlyCodeSigned() -> Bool {
+        guard let bundleURL = Bundle.main.bundleURL as CFURL? else { return false }
+        
+        var staticCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(bundleURL, [], &staticCode) == errSecSuccess,
+              let code = staticCode else { return false }
+        
+        // Check for valid signature (not ad-hoc)
+        var requirement: SecRequirement?
+        let requirementString = "anchor apple generic and certificate leaf[subject.OU] exists"
+        guard SecRequirementCreateWithString(requirementString as CFString, [], &requirement) == errSecSuccess,
+              let req = requirement else { return false }
+        
+        return SecStaticCodeCheckValidity(code, [], req) == errSecSuccess
+    }
+    
+    /// Show helpful dialog if app is quarantined
+    static func showQuarantineHelpIfNeeded() {
+        // Only show if quarantined and not properly signed (most users)
+        guard isQuarantined() && !isProperlyCodeSigned() else {
+            return
+        }
+        
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = "First Time Setup"
+            alert.informativeText = """
+            Ping Warden is not code-signed by Apple, which is normal for open-source apps.
+            
+            If macOS prevented you from opening the app, you can fix this by:
+            
+            1. Opening Terminal
+            2. Running this command:
+            
+            xattr -cr "/Applications/Ping Warden.app"
+            
+            Then relaunch the app.
+            
+            This only needs to be done once!
+            """
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: "Copy Command")
+            alert.addButton(withTitle: "I Already Did This")
+            alert.addButton(withTitle: "More Info")
+            
+            let response = alert.runModal()
+            
+            switch response {
+            case .alertFirstButtonReturn: // Copy Command
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString("xattr -cr \"/Applications/Ping Warden.app\"", forType: .string)
+                
+                let confirmAlert = NSAlert()
+                confirmAlert.messageText = "Command Copied!"
+                confirmAlert.informativeText = "The command has been copied to your clipboard.\n\nPaste it into Terminal and press Enter."
+                confirmAlert.alertStyle = .informational
+                confirmAlert.addButton(withTitle: "OK")
+                confirmAlert.runModal()
+                
+            case .alertThirdButtonReturn: // More Info
+                if let url = URL(string: "https://github.com/oliverames/ping-warden#installation") {
+                    NSWorkspace.shared.open(url)
+                }
+                
+            default: // I Already Did This
+                break
+            }
+        }
+    }
+    
+    /// Attempt to remove quarantine attributes (requires admin privileges)
+    /// This generally doesn't work from within the app itself, but worth trying
+    static func attemptQuarantineRemoval() -> Bool {
+        guard let bundlePath = Bundle.main.bundlePath as NSString? else {
+            return false
+        }
+        
+        let path = bundlePath.utf8String!
+        let attrName = "com.apple.quarantine"
+        
+        // Try to remove quarantine attribute
+        let result = Darwin.removexattr(path, attrName, 0)
+        
+        return result == 0
+    }
+}

--- a/AWDLControl/AWDLControl/notarize.sh
+++ b/AWDLControl/AWDLControl/notarize.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+#
+#  notarize.sh
+#  Notarize Ping Warden for distribution
+#
+#  Usage: ./notarize.sh [version]
+#  Example: ./notarize.sh 2.0.1
+#
+#  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
+#  Licensed under the MIT License.
+#
+
+set -e
+
+# Configuration
+APP_NAME="Ping Warden"
+VERSION="${1:-2.0.1}"
+BUNDLE_ID="com.amesvt.pingwarden"
+KEYCHAIN_PROFILE="notarytool-profile"  # Must match setup in NOTARIZATION_GUIDE.md
+TEAM_ID="PV3W52NDZ3"  # Your Apple Developer Team ID
+
+# Paths
+BUILD_DIR="build"
+APP_PATH="${BUILD_DIR}/${APP_NAME}.app"
+DMG_NAME="PingWarden-${VERSION}.dmg"
+ZIP_NAME="PingWarden-${VERSION}.zip"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Ping Warden Notarization Script v${VERSION}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Step 1: Verify app exists
+if [ ! -d "$APP_PATH" ]; then
+    echo -e "${RED}Error: ${APP_PATH} not found${NC}"
+    echo "Please build the app in Xcode first:"
+    echo "  1. Product → Archive"
+    echo "  2. Export as Developer ID signed app"
+    echo "  3. Move to ${BUILD_DIR}/"
+    exit 1
+fi
+
+echo -e "${GREEN}✓${NC} App bundle found"
+
+# Step 2: Verify code signing
+echo ""
+echo "Verifying code signature..."
+if ! codesign --verify --deep --strict --verbose=2 "$APP_PATH" 2>&1 | grep -q "satisfies"; then
+    echo -e "${RED}Error: App is not properly code signed${NC}"
+    echo "Make sure you built with Developer ID Application certificate"
+    exit 1
+fi
+
+# Check for Developer ID signature (not ad-hoc)
+SIGNING_IDENTITY=$(codesign -dvv "$APP_PATH" 2>&1 | grep "Authority=Developer ID Application" || true)
+if [ -z "$SIGNING_IDENTITY" ]; then
+    echo -e "${RED}Error: App is not signed with Developer ID Application certificate${NC}"
+    echo "Current signature:"
+    codesign -dvv "$APP_PATH" 2>&1 | grep "Authority"
+    echo ""
+    echo "Please sign with Developer ID certificate in Xcode"
+    exit 1
+fi
+
+echo -e "${GREEN}✓${NC} Code signature valid"
+echo "  ${SIGNING_IDENTITY}"
+
+# Step 3: Create ZIP for notarization
+echo ""
+echo "Creating ZIP archive for notarization..."
+cd "$BUILD_DIR"
+ditto -c -k --keepParent "${APP_NAME}.app" "../${ZIP_NAME}"
+cd ..
+
+echo -e "${GREEN}✓${NC} Created ${ZIP_NAME}"
+
+# Step 4: Submit for notarization
+echo ""
+echo "Submitting to Apple for notarization..."
+echo "This may take 1-10 minutes..."
+echo ""
+
+SUBMIT_OUTPUT=$(xcrun notarytool submit "$ZIP_NAME" \
+    --keychain-profile "$KEYCHAIN_PROFILE" \
+    --wait 2>&1)
+
+echo "$SUBMIT_OUTPUT"
+
+# Check if submission succeeded
+if echo "$SUBMIT_OUTPUT" | grep -q "status: Accepted"; then
+    echo ""
+    echo -e "${GREEN}✓ Notarization successful!${NC}"
+else
+    echo ""
+    echo -e "${RED}✗ Notarization failed${NC}"
+    exit 1
+fi
+
+# Step 5: Staple the ticket
+echo ""
+echo "Stapling notarization ticket..."
+xcrun stapler staple "$APP_PATH"
+
+echo -e "${GREEN}✓${NC} Ticket stapled successfully"
+
+# Step 6: Create notarized DMG
+echo ""
+echo "Creating notarized DMG..."
+if [ -f "create-dmg.sh" ]; then
+    ./create-dmg.sh "$VERSION"
+    
+    if [ -f "$DMG_NAME" ]; then
+        echo "Stapling DMG..."
+        xcrun stapler staple "$DMG_NAME"
+        echo -e "${GREEN}✓${NC} DMG stapled"
+    fi
+fi
+
+# Summary
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${GREEN}Notarization Complete!${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Notarized files:"
+echo "  • ${APP_PATH}"
+if [ -f "$DMG_NAME" ]; then
+    echo "  • ${DMG_NAME}"
+fi
+echo ""
+echo -e "${GREEN}Done!${NC} 🎉"
+echo ""
+
+# Clean up
+rm "$ZIP_NAME"
+

--- a/AWDLControl/AWDLControl/release.sh
+++ b/AWDLControl/AWDLControl/release.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+#
+#  release.sh
+#  Complete release automation: notarize + create DMG + update appcast + GitHub release
+#
+#  Usage: ./release.sh [version] [release-notes-file]
+#  Example: ./release.sh 2.1.0 release_notes_2.1.0.txt
+#
+#  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
+#  Licensed under the MIT License.
+#
+
+set -e
+
+# Configuration
+VERSION="${1}"
+RELEASE_NOTES="${2:-RELEASE_NOTES.md}"
+APP_NAME="Ping Warden"
+BUNDLE_ID="com.amesvt.pingwarden"
+DMG_NAME="PingWarden-${VERSION}.dmg"
+ZIP_NAME="PingWarden-${VERSION}.zip"
+BUILD_DIR="build"
+SPARKLE_KEY="$HOME/sparkle_private_key"
+GITHUB_USER="oliverames"
+REPO_NAME="ping-warden"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Validation
+if [ -z "$VERSION" ]; then
+    echo -e "${RED}Error: Version required${NC}"
+    echo "Usage: ./release.sh [version] [release-notes-file]"
+    echo "Example: ./release.sh 2.1.0"
+    exit 1
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "  ${BLUE}Ping Warden Release Automation v${VERSION}${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Step 1: Notarize
+echo -e "${GREEN}Step 1: Notarizing app...${NC}"
+./notarize.sh "$VERSION"
+
+if [ $? -ne 0 ]; then
+    echo -e "${RED}Notarization failed!${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ Notarization complete${NC}"
+echo ""
+
+# Step 2: Verify DMG exists
+if [ ! -f "$DMG_NAME" ]; then
+    echo -e "${RED}Error: DMG not found: $DMG_NAME${NC}"
+    echo "notarize.sh should have created it"
+    exit 1
+fi
+
+echo -e "${GREEN}✓ DMG found: $DMG_NAME${NC}"
+echo ""
+
+# Step 3: Sign update for Sparkle (if key exists)
+if [ -f "$SPARKLE_KEY" ]; then
+    echo -e "${GREEN}Step 2: Signing update for Sparkle...${NC}"
+    
+    # Find sign_update tool (from Sparkle SPM package)
+    SIGN_TOOL=$(find ~/Library/Developer/Xcode/DerivedData -name "sign_update" -type f 2>/dev/null | head -1)
+    
+    if [ -z "$SIGN_TOOL" ]; then
+        echo -e "${YELLOW}⚠ sign_update tool not found${NC}"
+        echo "Sparkle may not be installed yet. Skipping signature."
+        SIGNATURE=""
+    else
+        # Create ZIP if it doesn't exist (notarize.sh cleans it up)
+        if [ ! -f "$ZIP_NAME" ]; then
+            cd "$BUILD_DIR"
+            ditto -c -k --keepParent "${APP_NAME}.app" "../${ZIP_NAME}"
+            cd ..
+        fi
+        
+        SIGNATURE=$("$SIGN_TOOL" "$ZIP_NAME" --ed-key-file "$SPARKLE_KEY")
+        echo -e "${GREEN}✓ Signature: ${SIGNATURE}${NC}"
+    fi
+else
+    echo -e "${YELLOW}⚠ Sparkle private key not found at $SPARKLE_KEY${NC}"
+    echo "Skipping Sparkle signature (updates won't work until you add Sparkle)"
+    SIGNATURE=""
+fi
+
+echo ""
+
+# Step 4: Get file size and date
+DMG_SIZE=$(stat -f%z "$DMG_NAME")
+DMG_DATE=$(date -u +"%a, %d %b %Y %H:%M:%S %Z")
+
+echo -e "${GREEN}Step 3: Preparing release metadata...${NC}"
+echo "  Version: $VERSION"
+echo "  DMG Size: $DMG_SIZE bytes"
+echo "  Date: $DMG_DATE"
+echo ""
+
+# Step 5: Update appcast.xml
+echo -e "${GREEN}Step 4: Updating appcast.xml...${NC}"
+
+# Check if appcast exists
+APPCAST_FILE="appcast.xml"
+if [ ! -f "$APPCAST_FILE" ]; then
+    echo "Creating new appcast.xml"
+    cat > "$APPCAST_FILE" << 'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Ping Warden Updates</title>
+    <link>https://GITHUB_USER.github.io/REPO_NAME/appcast.xml</link>
+    <description>Updates for Ping Warden</description>
+    <language>en</language>
+  </channel>
+</rss>
+EOF
+    # Replace placeholders
+    sed -i "" "s/GITHUB_USER/$GITHUB_USER/g" "$APPCAST_FILE"
+    sed -i "" "s/REPO_NAME/$REPO_NAME/g" "$APPCAST_FILE"
+fi
+
+# Create new item entry
+NEW_ITEM="    <item>
+      <title>Version $VERSION</title>
+      <link>https://github.com/$GITHUB_USER/$REPO_NAME/releases/tag/v$VERSION</link>
+      <sparkle:version>$VERSION</sparkle:version>
+      <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
+      <description><![CDATA[
+        <h2>What's New in $VERSION</h2>
+        <p>See release notes on GitHub</p>
+      ]]></description>
+      <pubDate>$DMG_DATE</pubDate>
+      <enclosure
+        url=\"https://github.com/$GITHUB_USER/$REPO_NAME/releases/download/v$VERSION/$DMG_NAME\"
+        sparkle:version=\"$VERSION\"
+        sparkle:shortVersionString=\"$VERSION\"
+        length=\"$DMG_SIZE\"
+        type=\"application/octet-stream\"
+        $([ -n "$SIGNATURE" ] && echo "sparkle:edSignature=\"$SIGNATURE\"")
+      />
+    </item>"
+
+# Insert new item after <language>en</language> line
+sed -i "" "/<language>en<\/language>/a\\
+$NEW_ITEM
+" "$APPCAST_FILE"
+
+echo -e "${GREEN}✓ Appcast updated${NC}"
+echo ""
+
+# Step 6: Create GitHub release
+echo -e "${GREEN}Step 5: Creating GitHub release...${NC}"
+
+if ! command -v gh &> /dev/null; then
+    echo -e "${YELLOW}⚠ GitHub CLI (gh) not installed${NC}"
+    echo ""
+    echo "To create release manually:"
+    echo "1. Go to https://github.com/$GITHUB_USER/$REPO_NAME/releases/new"
+    echo "2. Tag: v$VERSION"
+    echo "3. Title: Ping Warden v$VERSION"
+    echo "4. Upload: $DMG_NAME"
+    echo "5. Copy notes from $RELEASE_NOTES"
+    echo ""
+else
+    # Create release with gh CLI
+    if [ -f "$RELEASE_NOTES" ]; then
+        gh release create "v$VERSION" \
+            "$DMG_NAME" \
+            --title "Ping Warden v$VERSION" \
+            --notes-file "$RELEASE_NOTES"
+    else
+        gh release create "v$VERSION" \
+            "$DMG_NAME" \
+            --title "Ping Warden v$VERSION" \
+            --notes "See CHANGELOG for details"
+    fi
+    
+    echo -e "${GREEN}✓ GitHub release created${NC}"
+fi
+
+echo ""
+
+# Step 7: Instructions for appcast
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${GREEN}Release Complete!${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Next steps:"
+echo ""
+echo "1. Update appcast on GitHub Pages:"
+echo "   ${BLUE}git checkout gh-pages${NC}"
+echo "   ${BLUE}cp appcast.xml .${NC}"
+echo "   ${BLUE}git add appcast.xml${NC}"
+echo "   ${BLUE}git commit -m 'Update appcast for v$VERSION'${NC}"
+echo "   ${BLUE}git push origin gh-pages${NC}"
+echo "   ${BLUE}git checkout main${NC}"
+echo ""
+echo "2. Test the update:"
+echo "   - Install an older version"
+echo "   - Click 'Check for Updates'"
+echo "   - Verify v$VERSION is offered"
+echo ""
+echo "3. Announce on Reddit:"
+echo "   - r/GeForceNOW"
+echo "   - r/xcloud"
+echo "   - r/macgaming"
+echo ""
+echo "Release artifacts:"
+echo "  • $DMG_NAME"
+echo "  • GitHub release: https://github.com/$GITHUB_USER/$REPO_NAME/releases/tag/v$VERSION"
+echo "  • Appcast: $APPCAST_FILE (needs to be pushed to gh-pages)"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""

--- a/AWDLControl/AWDLControlHelper/AWDLMonitor.h
+++ b/AWDLControl/AWDLControlHelper/AWDLMonitor.h
@@ -28,6 +28,13 @@ NS_ASSUME_NONNULL_BEGIN
 /// Should be called before the helper exits.
 - (void)invalidate;
 
+/// Get the total number of AWDL interventions (how many times we blocked AWDL from coming up)
+/// This counter persists for the lifetime of the helper process
+- (NSInteger)getInterventionCount;
+
+/// Reset the intervention counter to zero
+- (void)resetInterventionCount;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/AWDLControl/AWDLControlHelper/Info.plist
+++ b/AWDLControl/AWDLControlHelper/Info.plist
@@ -2,22 +2,22 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleIdentifier</key>
-	<string>com.awdlcontrol.helper</string>
-	<key>CFBundleName</key>
-	<string>AWDLControlHelper</string>
 	<key>CFBundleDisplayName</key>
 	<string>AWDL Control Helper</string>
-	<key>CFBundleVersion</key>
-	<string>2.0.1</string>
-	<key>CFBundleShortVersionString</key>
-	<string>2.0.1</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundlePackageType</key>
-	<string>BNDL</string>
 	<key>CFBundleExecutable</key>
 	<string>AWDLControlHelper</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>AWDLControlHelper</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.0.1</string>
+	<key>CFBundleVersion</key>
+	<string>2.0.1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>NSHumanReadableCopyright</key>

--- a/AWDLControl/AWDLControlHelper/com.amesvt.pingwarden.helper.plist
+++ b/AWDLControl/AWDLControlHelper/com.amesvt.pingwarden.helper.plist
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
-  com.awdlcontrol.helper.plist
-  SMAppService daemon configuration for AWDLControlHelper
+  com.amesvt.pingwarden.helper.plist
+  SMAppService daemon configuration for AWDLControlHelper (Ping Warden)
 
   Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
   Licensed under the MIT License.
@@ -10,20 +10,20 @@
 <plist version="1.0">
 <dict>
 	<key>Label</key>
-	<string>com.awdlcontrol.helper</string>
+	<string>com.amesvt.pingwarden.helper</string>
 
 	<key>BundleProgram</key>
 	<string>Contents/MacOS/AWDLControlHelper</string>
 
 	<key>AssociatedBundleIdentifiers</key>
 	<array>
-		<string>com.awdlcontrol.app</string>
-		<string>com.awdlcontrol.app.widget</string>
+		<string>com.amesvt.pingwarden</string>
+		<string>com.amesvt.pingwarden.widget</string>
 	</array>
 
 	<key>MachServices</key>
 	<dict>
-		<key>com.awdlcontrol.xpc.helper</key>
+		<key>com.amesvt.pingwarden.xpc</key>
 		<true/>
 	</dict>
 

--- a/AWDLControl/AWDLControlWidget/AWDLControlWidget.entitlements
+++ b/AWDLControl/AWDLControlWidget/AWDLControlWidget.entitlements
@@ -4,9 +4,5 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.awdlcontrol.app</string>
-	</array>
 </dict>
 </plist>

--- a/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLPreferences.swift
@@ -11,7 +11,7 @@
 import Foundation
 import os.log
 
-private let log = Logger(subsystem: "com.awdlcontrol.app", category: "WidgetPreferences")
+private let log = Logger(subsystem: "com.amesvt.pingwarden", category: "WidgetPreferences")
 
 /// Manages shared state between app and widget using App Groups
 /// Note: This file should be kept in sync with AWDLControl/AWDLPreferences.swift
@@ -20,7 +20,7 @@ private let log = Logger(subsystem: "com.awdlcontrol.app", category: "WidgetPref
 class AWDLPreferences {
     static let shared = AWDLPreferences()
 
-    private let appGroupID = "group.com.awdlcontrol.app"
+    private let appGroupID = "group.com.amesvt.pingwarden"
     private let monitoringEnabledKey = "AWDLMonitoringEnabled"
     private let lastStateKey = "AWDLLastState"
     private let controlCenterEnabledKey = "ControlCenterWidgetEnabled"
@@ -127,7 +127,7 @@ class AWDLPreferences {
 
 extension Notification.Name {
     // Use a namespaced notification name to avoid collisions with other apps
-    static let awdlMonitoringStateChanged = Notification.Name("com.awdlcontrol.notification.MonitoringStateChanged")
+    static let awdlMonitoringStateChanged = Notification.Name("com.amesvt.pingwarden.notification.MonitoringStateChanged")
     // These are defined in the main app but included here for reference:
     // static let controlCenterModeChanged = Notification.Name("com.awdlcontrol.notification.ControlCenterModeChanged")
     // static let gameModeAutoDetectChanged = Notification.Name("com.awdlcontrol.notification.GameModeAutoDetectChanged")

--- a/AWDLControl/AWDLControlWidget/AWDLToggleIntent.swift
+++ b/AWDLControl/AWDLControlWidget/AWDLToggleIntent.swift
@@ -13,7 +13,7 @@ import AppKit
 import Foundation
 import os.log
 
-private let log = Logger(subsystem: "com.awdlcontrol.app", category: "WidgetIntent")
+private let log = Logger(subsystem: "com.amesvt.pingwarden", category: "WidgetIntent")
 
 /// App Intent to toggle AWDL monitoring (used by Control Widget button)
 /// When enabled, continuously monitors and keeps AWDL down.
@@ -55,7 +55,7 @@ struct ToggleAWDLMonitoringIntent: AppIntent {
 
     /// Launch the main app if it's not already running
     private func launchMainAppIfNeeded() async {
-        let bundleIdentifier = "com.awdlcontrol.app"
+        let bundleIdentifier = "com.amesvt.pingwarden"
 
         // Check if app is already running
         let runningApps = NSWorkspace.shared.runningApplications

--- a/AWDLControl/AWDLControlWidget/Info.plist
+++ b/AWDLControl/AWDLControlWidget/Info.plist
@@ -4,8 +4,8 @@
 <dict>
 	<key>CFBundleDisplayName</key>
 	<string>Ping Warden Widget</string>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2025-2026 Oliver Ames. All rights reserved.</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -14,8 +14,6 @@
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>2.0.1</string>
 	<key>CFBundleVersion</key>
@@ -25,5 +23,7 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.widgetkit-extension</string>
 	</dict>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2025-2026 Oliver Ames. All rights reserved.</string>
 </dict>
 </plist>

--- a/AWDLControl/Common/HelperProtocol.h
+++ b/AWDLControl/Common/HelperProtocol.h
@@ -32,4 +32,12 @@
 /// @param reply Callback with version string
 - (void)getVersionWithReply:(void (^_Nonnull)(NSString *_Nonnull version))reply NS_SWIFT_NAME(getVersion(reply:));
 
+/// Get the number of AWDL interventions (how many times AWDL was blocked from coming up)
+/// @param reply Callback with intervention count
+- (void)getAWDLInterventionCountWithReply:(void (^_Nonnull)(NSInteger count))reply NS_SWIFT_NAME(getAWDLInterventionCount(reply:));
+
+/// Reset the AWDL intervention counter to zero
+/// @param reply Callback with success status
+- (void)resetAWDLInterventionCountWithReply:(void (^_Nonnull)(BOOL success))reply NS_SWIFT_NAME(resetAWDLInterventionCount(reply:));
+
 @end

--- a/AWDLControl/QUICKSTART.md
+++ b/AWDLControl/QUICKSTART.md
@@ -1,0 +1,121 @@
+# Quick Start Guide
+
+## 🚀 Get Started in 3 Steps
+
+### 1️⃣ Install
+
+**Option A: Automated** (Recommended)
+```bash
+chmod +x install.sh
+./install.sh
+```
+
+**Option B: Manual**
+1. Drag `Ping Warden.app` to Applications
+2. Right-click → Open
+3. Click "Open" in the dialog
+
+---
+
+### 2️⃣ First Launch
+
+1. Click **"Set Up Now"**
+2. **Approve** in System Settings → Login Items
+3. ✅ Done!
+
+---
+
+### 3️⃣ Use It
+
+Click the antenna icon `📡` in your menu bar to:
+- Toggle AWDL blocking
+- View status
+- Adjust settings
+
+**Icon meanings:**
+- `📡` with slash = Blocking (low latency) ✅
+- `📡` no slash = Allowing (AirDrop works) 
+
+---
+
+## ⚠️ Getting "Can't be opened" error?
+
+This is normal for unnotarized apps. Fix:
+
+**Quick fix:**
+```bash
+xattr -cr "/Applications/Ping Warden.app"
+```
+
+**Or:** Right-click → Open (instead of double-clicking)
+
+See [README.md](README.md#installation) for full details.
+
+---
+
+## 🎮 Gaming Setup
+
+For automatic activation during games:
+
+1. Open **Settings** → **Automation**
+2. Enable **"Game Mode Auto-Detect"**
+3. Grant **Screen Recording** permission
+4. Done! It activates automatically when you game
+
+---
+
+## 🎛️ Control Center Setup (Optional)
+
+For quick toggle from Control Center:
+
+1. Settings → Automation → Enable "Control Center Widget"
+2. System Settings → Control Center
+3. Scroll to "Ping Warden"
+4. Add to menu bar or Control Center
+
+**Note:** Requires code-signed app
+
+---
+
+## 📊 Verify It's Working
+
+### Quick Test
+
+1. Enable blocking (menu bar icon should show slash)
+2. Settings → Advanced → "Run Test"
+3. All tests should **PASS** with <1ms response time
+
+### Real-World Test
+
+**Before:**
+```bash
+ping -c 10 8.8.8.8
+# Check for occasional 100-300ms spikes
+```
+
+**After enabling Ping Warden:**
+```bash
+ping -c 10 8.8.8.8
+# Spikes should be gone! Stable <10ms pings
+```
+
+---
+
+## 🆘 Need Help?
+
+- 📖 [Full README](README.md)
+- 🔧 [Troubleshooting Guide](TROUBLESHOOTING.md)
+- 🐛 [Report an Issue](https://github.com/yourusername/ping-warden/issues)
+
+---
+
+## 💡 Pro Tips
+
+1. **Launch at login** - Settings → General → Enable "Launch at Login"
+2. **Hide dock icon** - Settings → General → Disable "Show Dock Icon"
+3. **Manual toggle** - Better than Game Mode for most users
+4. **Check status** - Menu bar icon shows current state at a glance
+
+---
+
+**That's it! Enjoy lag-free gaming and calls! 🎮📞**

--- a/AWDLControl/README.md
+++ b/AWDLControl/README.md
@@ -1,0 +1,205 @@
+# Ping Warden
+
+**Eliminate network latency spikes on macOS by controlling AWDL (Apple Wireless Direct Link)**
+
+Perfect for gaming, video calls, and any latency-sensitive applications.
+
+## Features
+
+- ⚡ **<1ms response time** - Kernel-level AWDL monitoring
+- 🎮 **Zero performance impact** - 0% CPU when idle
+- 🔒 **No password prompts** - One-time system approval
+- 🎯 **Game Mode detection** - Auto-enable for fullscreen games (Beta)
+- 🎛️ **Control Center widget** - Quick toggle from Control Center (Beta)
+- 🚀 **Launch at login** - Set it and forget it
+
+## What does it do?
+
+AWDL (Apple Wireless Direct Link) is used by AirDrop, Handoff, and other continuity features. However, it can cause **100-300ms ping spikes** every few seconds, which is devastating for:
+
+- **Gaming** (especially competitive online games)
+- **Video calls** (Zoom, Teams, Discord)
+- **Live streaming**
+- **Remote desktop** (VNC, RDP)
+
+Ping Warden monitors the AWDL interface and keeps it disabled when you need low latency. When you quit the app, AWDL is automatically restored.
+
+## Installation
+
+### ⚠️ Important: macOS Security Notice
+
+macOS may show a warning that "Ping Warden can't be opened" or "cannot be verified as free of malware." This is normal for apps that aren't notarized by Apple. Choose one of the installation methods below:
+
+---
+
+### Method 1: Automated Installation (Easiest)
+
+1. **Download** the latest release
+2. **Unzip** the download
+3. **Open Terminal** in the unzipped folder
+4. **Run** the installer:
+   ```bash
+   chmod +x install.sh
+   ./install.sh
+   ```
+
+The installer automatically removes quarantine flags and installs to `/Applications`.
+
+---
+
+### Method 2: Manual Installation (Right-Click Method)
+
+1. **Download** the latest release
+2. **Unzip** and move `Ping Warden.app` to your **Applications** folder
+3. **Right-click** (or Control-click) on `Ping Warden.app`
+4. Select **"Open"** from the menu
+5. Click **"Open"** in the dialog
+
+This only needs to be done once.
+
+---
+
+### Method 3: Terminal Command
+
+1. **Download** and unzip
+2. **Move** `Ping Warden.app` to `/Applications`
+3. **Run** this command in Terminal:
+   ```bash
+   xattr -cr "/Applications/Ping Warden.app"
+   ```
+4. **Launch** from Applications or Spotlight
+
+---
+
+## First Launch Setup
+
+1. **Launch** Ping Warden
+2. Click **"Set Up Now"** in the welcome window
+3. **Approve** the helper in System Settings → Login Items & Extensions → Login Items
+4. The app is now ready to use!
+
+The helper daemon runs only while the app is open and automatically cleans up when you quit.
+
+## Usage
+
+### Menu Bar
+
+Click the antenna icon in the menu bar to:
+- Toggle AWDL blocking on/off
+- View current status
+- Access Settings
+- View diagnostics
+
+**Icon states:**
+- `📡` (with slash) - AWDL blocked (low latency mode)
+- `📡` (no slash) - AWDL allowed (AirDrop/Handoff work)
+
+### Settings
+
+**General:**
+- Enable/disable AWDL blocking
+- Launch at login
+- Show/hide Dock icon
+
+**Automation:**
+- **Game Mode Auto-Detect** (Beta) - Automatically enables blocking when fullscreen games are running
+  - Requires Screen Recording permission
+  - Only detects apps marked as games in their Info.plist
+  
+- **Control Center Widget** (Beta) - Adds a toggle to Control Center
+  - Requires code-signed app (Developer ID certificate)
+  - Ad-hoc signed builds use menu bar instead
+
+**Advanced:**
+- Test helper response time
+- View logs in Console.app
+- Re-register helper (if experiencing issues)
+- Uninstall helper
+
+## How It Works
+
+Ping Warden uses a privileged helper daemon that:
+
+1. **Monitors** the `awdl0` interface using AF_ROUTE socket (kernel-level)
+2. **Detects** when macOS tries to bring AWDL up
+3. **Responds** in <1ms to bring it back down
+4. **Restores** AWDL to enabled state when you quit
+
+**Why this approach?**
+- ✅ No password prompts (SMAppService architecture)
+- ✅ Extremely fast response (<1ms)
+- ✅ Zero CPU usage when idle
+- ✅ Automatic cleanup on exit
+- ✅ Secure (helper only runs while app is open)
+
+## System Requirements
+
+- macOS 13.0 (Ventura) or later
+- Apple Silicon or Intel Mac
+
+**Optional features:**
+- Game Mode Auto-Detect: macOS 15.0+ (requires Screen Recording permission)
+- Control Center Widget: Requires code-signed app
+
+## Troubleshooting
+
+### "Ping Warden can't be opened"
+
+See the [Installation](#installation) section above. This is a macOS Gatekeeper issue, not a problem with the app.
+
+### Helper not responding
+
+1. Open Settings → Advanced
+2. Click "Re-register Helper"
+3. Approve in System Settings if prompted
+
+### AWDL still causing lag
+
+1. Check that monitoring is enabled (menu bar icon should show slash)
+2. Open Settings → Advanced → "Test Helper Response"
+3. Check Console.app for errors (filter by "awdlcontrol")
+
+### Game Mode not working
+
+1. Ensure you're on macOS 15.0+
+2. Grant Screen Recording permission in System Settings → Privacy & Security
+3. Only apps marked as games (LSApplicationCategoryType = games) will trigger detection
+
+## Performance
+
+Measured on M1 MacBook Pro:
+
+| Metric | Value |
+|--------|-------|
+| Response time | <1ms |
+| CPU usage (idle) | 0% |
+| CPU usage (active) | <0.1% |
+| Memory usage | ~8 MB |
+| Network overhead | None |
+
+## Known Issues
+
+- Control Center widget requires code signing (Developer ID certificate)
+- Game Mode detection requires Screen Recording permission
+- Some third-party networking tools may conflict with AWDL control
+
+## Credits
+
+This project builds on excellent prior work:
+
+- **[jamestut/awdlkiller](https://github.com/jamestut/awdlkiller)** - AF_ROUTE monitoring concept
+- **[james-howard/AWDLControl](https://github.com/james-howard/AWDLControl)** - SMAppService + XPC architecture
+
+## License
+
+MIT License - see LICENSE file for details
+
+Copyright (c) 2025-2026 Oliver Ames
+
+## Support
+
+For issues, questions, or feature requests, please open an issue on GitHub.
+
+---
+
+**Note:** This app controls system-level networking. While it's designed to be safe and automatically restores AWDL when you quit, you may want to disable it if you need AirDrop or Handoff. Simply toggle it off in the menu bar or quit the app.

--- a/AWDLControl/TROUBLESHOOTING.md
+++ b/AWDLControl/TROUBLESHOOTING.md
@@ -1,0 +1,337 @@
+# Troubleshooting Guide
+
+This guide covers common issues and their solutions.
+
+## Installation Issues
+
+### ❌ "Ping Warden.app can't be opened"
+
+**Cause:** macOS Gatekeeper blocking unsigned/unnotarized apps
+
+**Solutions:**
+
+1. **Right-click method** (Easiest):
+   - Right-click (or Control-click) on `Ping Warden.app`
+   - Select "Open" from the menu
+   - Click "Open" in the dialog
+   - Only needed once!
+
+2. **Terminal method**:
+   ```bash
+   xattr -cr "/Applications/Ping Warden.app"
+   open "/Applications/Ping Warden.app"
+   ```
+
+3. **Use the installer script**:
+   ```bash
+   chmod +x install.sh
+   ./install.sh
+   ```
+
+### ❌ "cannot be verified as free of malware"
+
+This is the same issue as above. See solutions above.
+
+**Why does this happen?**
+- The app is not notarized by Apple (requires $99/year developer account)
+- macOS marks downloaded files with a "quarantine" flag
+- Gatekeeper blocks quarantined, unnotarized apps
+
+**Is it safe?**
+- Yes! The source code is available for inspection
+- The app only controls the AWDL network interface
+- No data collection, no network requests, no telemetry
+
+---
+
+## Helper Installation Issues
+
+### ❌ Helper not registering / "Not Set Up" status
+
+**Solution 1: Manual approval**
+
+1. Open System Settings
+2. Go to "Login Items & Extensions" (or just "Login Items" on older macOS)
+3. Look for "AWDLControlHelper" or "Ping Warden" in the list
+4. Enable it if it's disabled
+5. Restart Ping Warden
+
+**Solution 2: Re-register**
+
+1. Open Ping Warden Settings
+2. Go to "Advanced" tab
+3. Click "Re-register Helper"
+4. Approve in System Settings if prompted
+
+**Solution 3: Clean reinstall**
+
+1. Quit Ping Warden
+2. Open Terminal and run:
+   ```bash
+   # Remove app
+   rm -rf "/Applications/Ping Warden.app"
+   
+   # Remove preferences
+   defaults delete com.amesvt.pingwarden.app
+   rm -rf ~/Library/Preferences/com.amesvt.pingwarden.app.plist
+   rm -rf ~/Library/Group\ Containers/group.com.amesvt.pingwarden.app
+   
+   # Reinstall
+   # (use one of the installation methods from README.md)
+   ```
+
+### ❌ "Operation not permitted" when registering helper
+
+**Cause:** This is normal! It means the helper needs approval.
+
+**Solution:**
+1. System Settings will automatically open (or click "Open System Settings")
+2. Look for "AWDLControlHelper" or "Ping Warden"
+3. Toggle it ON
+4. Close System Settings
+5. The app will detect approval automatically
+
+---
+
+## Runtime Issues
+
+### ❌ AWDL blocking not working / Ping still spikes
+
+**Diagnosis:**
+
+1. Check menu bar icon:
+   - Should show `📡` with slash when blocking
+   - Should show `📡` without slash when allowing
+
+2. Check status in Settings → General:
+   - Should show "Blocking AWDL" (green) when enabled
+
+3. Test helper response (Settings → Advanced → "Run Test"):
+   - All tests should PASS
+   - Response time should be <1ms
+
+**Solutions:**
+
+If tests fail:
+
+1. **Re-register helper** (Settings → Advanced → "Re-register...")
+2. **Check Console.app** for errors:
+   ```
+   - Open Console.app
+   - Filter by "awdlcontrol"
+   - Look for errors (red messages)
+   ```
+3. **Verify AWDL interface exists**:
+   ```bash
+   ifconfig awdl0
+   ```
+   - If this shows "no such device", your Mac may not have AWDL
+   - This is rare but can happen on some Mac models
+
+4. **Check for conflicting software**:
+   - VPN software that modifies network interfaces
+   - Other AWDL control tools
+   - Network monitoring tools
+
+### ❌ High CPU usage
+
+**Normal:** 0% when idle, <0.1% when actively blocking AWDL
+
+**If higher:**
+
+1. Check Game Mode auto-detect:
+   - If enabled, it scans for fullscreen apps every 2 seconds
+   - Without Screen Recording permission, this may be inefficient
+   - Try disabling in Settings → Automation
+
+2. Check for errors in Console.app (filter by "awdlcontrol")
+
+3. Try re-registering helper (Settings → Advanced)
+
+### ❌ App crashes on launch
+
+**Solution:**
+
+1. Check Console.app for crash logs:
+   - Look for `Ping Warden` or `AWDLControlHelper` crashes
+   
+2. Try safe mode launch:
+   ```bash
+   # Reset all preferences
+   defaults delete com.amesvt.pingwarden.app
+   
+   # Relaunch
+   open "/Applications/Ping Warden.app"
+   ```
+
+3. Check macOS version:
+   - Requires macOS 13.0 (Ventura) or later
+
+---
+
+## Feature-Specific Issues
+
+### ❌ Game Mode auto-detect not working
+
+**Requirements:**
+- macOS 15.0 or later
+- Screen Recording permission granted
+- App must be categorized as a game in its Info.plist
+
+**Solutions:**
+
+1. **Grant Screen Recording permission**:
+   - System Settings → Privacy & Security → Screen Recording
+   - Enable "Ping Warden"
+   - Restart Ping Warden
+
+2. **Check if game is detected as a game**:
+   - Not all fullscreen apps trigger Game Mode
+   - Only apps with `LSApplicationCategoryType = games` or `LSSupportsGameMode = true`
+   - Use manual toggle for non-game fullscreen apps
+
+3. **Test with known games**:
+   - Try with Steam games
+   - Try with Mac App Store games
+
+**Note:** This feature is marked as Beta for a reason. Manual toggle is more reliable.
+
+### ❌ Control Center widget not appearing
+
+**Cause:** Requires code-signed app (Developer ID certificate)
+
+**Check if available:**
+1. Open Settings → Automation
+2. Look at "Control Center Widget" toggle
+3. If it shows "Unavailable" badge, the app isn't properly signed
+
+**Workaround:**
+- Use menu bar interface instead
+- Control Center widget requires $99/year Apple Developer Program
+
+---
+
+## Performance Issues
+
+### ❌ Menu bar icon not updating
+
+**Solution:**
+
+1. Toggle monitoring off and on again
+2. Quit and restart the app
+3. Check if helper is running:
+   ```bash
+   # Should show AWDLControlHelper process
+   ps aux | grep AWDLControlHelper
+   ```
+
+### ❌ Settings window won't open
+
+**Solution:**
+
+1. Try clicking Settings menu item again (wait a few seconds)
+2. If still stuck, quit and restart the app
+3. Check Console.app for errors
+
+---
+
+## Uninstallation
+
+### Complete removal
+
+1. **Using the app:**
+   - Settings → Advanced → "Uninstall..."
+   - This unregisters the helper and quits
+
+2. **Manual removal:**
+   ```bash
+   # Stop and remove helper (if running)
+   sudo launchctl remove com.amesvt.pingwarden.helper 2>/dev/null || true
+   
+   # Remove app
+   rm -rf "/Applications/Ping Warden.app"
+   
+   # Remove preferences
+   defaults delete com.amesvt.pingwarden.app
+   rm -rf ~/Library/Preferences/com.amesvt.pingwarden.app.plist
+   rm -rf ~/Library/Group\ Containers/group.com.amesvt.pingwarden.app
+   
+   # Remove login item
+   # Go to System Settings → Login Items
+   # Remove "Ping Warden" if present
+   ```
+
+3. **Verify AWDL is restored:**
+   ```bash
+   ifconfig awdl0
+   # Should show "UP" in the flags
+   ```
+
+---
+
+## Getting More Help
+
+### Collect diagnostic information
+
+Before reporting an issue, collect this information:
+
+1. **macOS version:**
+   ```bash
+   sw_vers
+   ```
+
+2. **App version:**
+   - About Ping Warden → Version number
+
+3. **Helper status:**
+   - Settings → General → Status
+
+4. **Console logs:**
+   - Open Console.app
+   - Filter by "awdlcontrol"
+   - Export last 100 lines
+
+5. **AWDL status:**
+   ```bash
+   ifconfig awdl0
+   ```
+
+### Report an issue
+
+Include the above diagnostic information when opening a GitHub issue.
+
+### Quick reference commands
+
+```bash
+# Check if app is running
+ps aux | grep "Ping Warden"
+
+# Check if helper is running
+ps aux | grep AWDLControlHelper
+
+# Check AWDL interface status
+ifconfig awdl0
+
+# Remove quarantine flag
+xattr -cr "/Applications/Ping Warden.app"
+
+# View logs in real-time
+log stream --predicate 'subsystem == "com.amesvt.pingwarden.app"' --level debug
+
+# Reset all preferences
+defaults delete com.amesvt.pingwarden.app
+```
+
+---
+
+## Known Limitations
+
+1. **Control Center widget** - Requires code signing (Developer ID)
+2. **Game Mode detection** - Only works with apps marked as games
+3. **Screen Recording permission** - Required for Game Mode detection
+4. **macOS 13.0+** - Older macOS versions not supported (SMAppService requirement)
+5. **AWDL availability** - Some Mac models may not have AWDL interface
+
+---
+
+**Still having issues?** Open an issue on GitHub with your diagnostic information!

--- a/AWDLControl/create-dmg.sh
+++ b/AWDLControl/create-dmg.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+#
+#  create-dmg.sh
+#  Creates a distributable DMG with installation instructions
+#
+#  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
+#  Licensed under the MIT License.
+#
+
+set -e
+
+# Configuration
+APP_NAME="Ping Warden"
+VERSION="${1:-2.0.1}"
+DMG_NAME="PingWarden-${VERSION}"
+BUILD_DIR="build"
+DMG_TEMP="dmg_temp"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Creating DMG for ${APP_NAME} v${VERSION}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Check if app exists
+if [ ! -d "${BUILD_DIR}/${APP_NAME}.app" ]; then
+    echo "Error: ${BUILD_DIR}/${APP_NAME}.app not found"
+    echo "Please build the app first using Xcode"
+    exit 1
+fi
+
+# Clean up previous temp directory
+rm -rf "$DMG_TEMP"
+mkdir -p "$DMG_TEMP"
+
+# Copy app
+echo "Copying app bundle..."
+cp -R "${BUILD_DIR}/${APP_NAME}.app" "$DMG_TEMP/"
+
+# Copy installer script
+echo "Copying installer script..."
+cp install.sh "$DMG_TEMP/"
+chmod +x "$DMG_TEMP/install.sh"
+
+# Create a symlink to Applications
+echo "Creating Applications symlink..."
+ln -s /Applications "$DMG_TEMP/Applications"
+
+# Create README for DMG
+cat > "$DMG_TEMP/README.txt" << 'EOF'
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  PING WARDEN - Installation Instructions
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+⚠️  IMPORTANT: macOS Security Notice
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+macOS may show a warning that "Ping Warden can't be opened" 
+or "cannot be verified as free of malware."
+
+This is normal for apps not notarized by Apple. Choose one 
+of the installation methods below:
+
+
+📦 METHOD 1: Automated Installer (Easiest)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Double-click "install.sh"
+2. If Terminal opens, click "OK"
+3. Follow the prompts
+
+OR open Terminal in this folder and run:
+   ./install.sh
+
+
+🖱️  METHOD 2: Manual Installation
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. Drag "Ping Warden.app" to the Applications folder
+2. Right-click (or Control-click) on "Ping Warden.app"
+3. Select "Open" from the menu
+4. Click "Open" in the dialog
+
+This only needs to be done once!
+
+
+💻 METHOD 3: Terminal Command
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Drag "Ping Warden.app" to Applications, then run:
+
+   xattr -cr "/Applications/Ping Warden.app"
+   open "/Applications/Ping Warden.app"
+
+
+🎮 What does Ping Warden do?
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Eliminates 100-300ms network latency spikes caused by AWDL
+(Apple Wireless Direct Link). Perfect for:
+
+  • Gaming (especially competitive online games)
+  • Video calls (Zoom, Teams, Discord)
+  • Live streaming
+  • Remote desktop
+
+
+✨ Features
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ⚡ <1ms response time
+  🎯 0% CPU when idle
+  🔒 No password prompts
+  🎮 Game Mode auto-detection
+  🚀 Launch at login support
+
+
+📝 First Launch
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+After installation, the first launch will ask you to:
+
+1. Approve the helper in System Settings → Login Items
+2. This is a one-time approval (no password needed)
+3. The helper only runs while the app is open
+
+
+💬 Support
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+For issues or questions, visit:
+https://github.com/yourusername/ping-warden
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF
+
+# Create DMG
+echo "Creating DMG..."
+rm -f "${DMG_NAME}.dmg"
+
+# Create DMG with nice settings
+hdiutil create -volname "${APP_NAME}" \
+    -srcfolder "$DMG_TEMP" \
+    -ov \
+    -format UDZO \
+    -imagekey zlib-level=9 \
+    "${DMG_NAME}.dmg"
+
+# Clean up
+echo "Cleaning up..."
+rm -rf "$DMG_TEMP"
+
+# Calculate DMG size
+DMG_SIZE=$(du -h "${DMG_NAME}.dmg" | cut -f1)
+
+echo ""
+echo -e "${GREEN}✓ DMG created successfully!${NC}"
+echo ""
+echo "  File: ${DMG_NAME}.dmg"
+echo "  Size: ${DMG_SIZE}"
+echo ""
+echo -e "${YELLOW}Next steps:${NC}"
+echo "  1. Test the DMG by mounting it"
+echo "  2. Verify all installation methods work"
+echo "  3. Upload to GitHub releases"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""

--- a/AWDLControl/install.sh
+++ b/AWDLControl/install.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+#  install.sh
+#  Ping Warden Installer
+#
+#  Removes quarantine attributes and installs to Applications folder.
+#
+#  Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
+#  Licensed under the MIT License.
+#
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+APP_NAME="Ping Warden.app"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_PATH="${SCRIPT_DIR}/${APP_NAME}"
+INSTALL_PATH="/Applications/${APP_NAME}"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Ping Warden Installer"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Check if app exists in current directory
+if [ ! -d "$APP_PATH" ]; then
+    echo -e "${RED}Error: ${APP_NAME} not found in current directory${NC}"
+    echo "Please run this script from the folder containing ${APP_NAME}"
+    exit 1
+fi
+
+# Check if already installed
+if [ -d "$INSTALL_PATH" ]; then
+    echo -e "${YELLOW}Ping Warden is already installed.${NC}"
+    read -p "Do you want to replace it? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Installation cancelled."
+        exit 0
+    fi
+    
+    # Kill running app if exists
+    echo "Stopping Ping Warden if running..."
+    killall "Ping Warden" 2>/dev/null || true
+    
+    # Remove old version
+    echo "Removing old version..."
+    rm -rf "$INSTALL_PATH"
+fi
+
+# Remove quarantine attribute (this is what fixes the Gatekeeper issue)
+echo "Removing quarantine attributes..."
+xattr -cr "$APP_PATH"
+
+# Copy to Applications
+echo "Installing to /Applications..."
+cp -R "$APP_PATH" "$INSTALL_PATH"
+
+# Remove quarantine from installed copy too (just to be safe)
+xattr -cr "$INSTALL_PATH"
+
+echo ""
+echo -e "${GREEN}✓ Installation complete!${NC}"
+echo ""
+echo "You can now launch Ping Warden from:"
+echo "  • Applications folder"
+echo "  • Spotlight (⌘ + Space, then type 'Ping Warden')"
+echo ""
+echo "First-time setup will ask for approval in System Settings → Login Items"
+echo ""
+
+# Ask if user wants to launch now
+read -p "Launch Ping Warden now? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "Launching..."
+    open "$INSTALL_PATH"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""


### PR DESCRIPTION
- Add onChangeCompat View extension for macOS 13+ compatibility The new onChange(of:initial:_:) API requires macOS 14.0+, so we now use a wrapper that conditionally uses the appropriate API
- Add reset button to intervention counter in General Settings Users can now clear the counter from the UI instead of only via Advanced Settings diagnostics
- Update all onChange usages to use onChangeCompat for consistency