### PR TITLE
v2.5.0: Comprehensive reliability audit — helper, XPC, widget, monitoring, release tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,19 @@ jobs:
         echo ""
         echo "All bundle structure requirements verified."
 
+  # The core package (PingWarden/PingWarden/Core) is pure Foundation/POSIX
+  # and compiles on Linux; running the suite here catches portability
+  # regressions that the macOS job can't see, and gives much faster feedback.
+  linux-core-tests:
+    runs-on: ubuntu-latest
+    container: swift:5.10
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Run core logic tests
+      run: swift test
+
   shell-lint:
     runs-on: macos-14
     steps:
@@ -141,6 +154,8 @@ jobs:
           PingWarden/PingWarden/notarize.sh
           PingWarden/PingWarden/release.sh
           PingWarden/create-dmg.sh
+          scripts/render_release_notes.sh
+          scripts/run-smoke-tests.sh
         )
         for f in "${scripts[@]}"; do
           echo "=== bash -n $f ==="

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,10 @@ The Foundation-only core helpers are covered by a SwiftPM test target driven
 by `Package.swift` at the repo root. The Xcode app build is unaffected — the
 package's `PingWardenCore` target points at `PingWarden/PingWarden/Core/` via
 an explicit `path:` so the same Swift sources back both build systems.
+The package is **cross-platform**: `TCPProbe` and the test suite compile on
+Linux (`#if canImport(Darwin)/Glibc` shims, poll(2) instead of select), and
+CI runs `swift test` on both `macos-14` and an `ubuntu-latest` Swift
+container. Keep new Core code Foundation/POSIX-only.
 
 ```bash
 swift test            # canonical command
@@ -61,11 +65,13 @@ swift test            # canonical command
 ```
 
 Coverage: `PingStatistics.calculate()` edge cases (empty, healthy, lossy,
-even-count median), `XPCReconnectPolicy.delayForAttempt` (backoff curve),
+even-count median, fair band, min/max, all-failures, single-sample jitter),
+`XPCReconnectPolicy.delayForAttempt` (backoff curve, 30 s cap, monotonicity),
 `TCPProbe` failure and success paths (invalid hostname, closed loopback port,
 open loopback port), `StateObserverRegistry` add/remove/snapshot lifecycle,
-and `HelperBundleValidator` failure modes (missing binary, missing plist,
-non-executable binary, valid bundle).
+`VersionPromptPolicy` (incl. single-component fail-closed), custom-target
+validation boundaries, and `HelperBundleValidator` failure modes (missing
+binary, missing plist, non-executable binary, valid bundle).
 
 ## Release Process
 

--- a/PingWarden/PingWarden.xcodeproj/project.pbxproj
+++ b/PingWarden/PingWarden.xcodeproj/project.pbxproj
@@ -413,7 +413,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.3;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden;
 				PRODUCT_NAME = "Ping Warden";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -454,7 +454,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.4.3;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden;
 				PRODUCT_NAME = "Ping Warden";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -650,7 +650,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.4.3;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -687,7 +687,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2.4.3;
+				MARKETING_VERSION = 2.5.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.amesvt.pingwarden.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/PingWarden/PingWarden/ControlCenterSupport.swift
+++ b/PingWarden/PingWarden/ControlCenterSupport.swift
@@ -7,8 +7,27 @@
 
 import Foundation
 import Security
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
 
 enum ControlCenterSupport {
+    /// Must match `PingWardenControlKind.pingProtection` in the widget target.
+    static let pingProtectionControlKind = "PingWardenWidget"
+
+    /// Ask Control Center to re-render the Ping Protection toggle. The main
+    /// app must call this whenever the monitoring intent or effective state
+    /// changes — the widget only re-reads shared defaults when reloaded, so
+    /// without this a menu-bar or Game Mode toggle leaves the Control Center
+    /// toggle displaying stale state indefinitely.
+    static func reloadPingProtectionControl() {
+        #if canImport(WidgetKit)
+        if #available(macOS 26.0, *) {
+            ControlCenter.shared.reloadControls(ofKind: pingProtectionControlKind)
+        }
+        #endif
+    }
+
     enum Availability: Equatable {
         case available
         case unsupportedOS

--- a/PingWarden/PingWarden/Core/CustomPingTargetStore.swift
+++ b/PingWarden/PingWarden/Core/CustomPingTargetStore.swift
@@ -82,6 +82,52 @@ final class CustomPingTargetStore {
     func load() -> [CustomPingTarget] {
         lock.lock()
         defer { lock.unlock() }
+        return loadLocked()
+    }
+
+    @discardableResult
+    func save(_ targets: [CustomPingTarget]) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return saveLocked(targets)
+    }
+
+    // Mutations hold the lock across the whole read-modify-write so
+    // concurrent callers cannot interleave and lose writes.
+
+    @discardableResult
+    func add(_ target: CustomPingTarget) -> [CustomPingTarget] {
+        lock.lock()
+        defer { lock.unlock() }
+        var targets = loadLocked()
+        targets.append(target)
+        saveLocked(targets)
+        return targets
+    }
+
+    @discardableResult
+    func remove(id: UUID) -> [CustomPingTarget] {
+        lock.lock()
+        defer { lock.unlock() }
+        var targets = loadLocked()
+        targets.removeAll { $0.id == id }
+        saveLocked(targets)
+        return targets
+    }
+
+    @discardableResult
+    func update(_ target: CustomPingTarget) -> [CustomPingTarget] {
+        lock.lock()
+        defer { lock.unlock() }
+        var targets = loadLocked()
+        if let index = targets.firstIndex(where: { $0.id == target.id }) {
+            targets[index] = target
+            saveLocked(targets)
+        }
+        return targets
+    }
+
+    private func loadLocked() -> [CustomPingTarget] {
         guard let data = userDefaults.data(forKey: storageKey) else {
             return []
         }
@@ -95,9 +141,7 @@ final class CustomPingTargetStore {
     }
 
     @discardableResult
-    func save(_ targets: [CustomPingTarget]) -> Bool {
-        lock.lock()
-        defer { lock.unlock() }
+    private func saveLocked(_ targets: [CustomPingTarget]) -> Bool {
         do {
             let data = try JSONEncoder().encode(targets)
             userDefaults.set(data, forKey: storageKey)
@@ -105,31 +149,5 @@ final class CustomPingTargetStore {
         } catch {
             return false
         }
-    }
-
-    @discardableResult
-    func add(_ target: CustomPingTarget) -> [CustomPingTarget] {
-        var targets = load()
-        targets.append(target)
-        save(targets)
-        return targets
-    }
-
-    @discardableResult
-    func remove(id: UUID) -> [CustomPingTarget] {
-        var targets = load()
-        targets.removeAll { $0.id == id }
-        save(targets)
-        return targets
-    }
-
-    @discardableResult
-    func update(_ target: CustomPingTarget) -> [CustomPingTarget] {
-        var targets = load()
-        if let index = targets.firstIndex(where: { $0.id == target.id }) {
-            targets[index] = target
-            save(targets)
-        }
-        return targets
     }
 }

--- a/PingWarden/PingWarden/Core/TCPProbe.swift
+++ b/PingWarden/PingWarden/Core/TCPProbe.swift
@@ -59,10 +59,17 @@ enum TCPProbe {
     /// getaddrinfo has no timeout of its own — an unresponsive resolver can
     /// block for ~30 s, which used to freeze the entire probe pipeline (the
     /// serial probe queue skipped every subsequent tick behind the hung
-    /// call). Run it on a detached thread and give it a bounded window; on
-    /// timeout the probe reports failure and the orphaned thread finishes on
-    /// its own.
+    /// call). IP-literal hosts (all the default targets: public DNS servers,
+    /// the local gateway, discovered GFN endpoints) can never hit the
+    /// resolver, so they resolve inline; only real hostnames pay for the
+    /// deadline-bounded detached thread — off the 2-second probe hot path.
+    /// On timeout the probe reports failure and the orphaned thread finishes
+    /// on its own.
     private static func resolveAddresses(host: String, port: UInt16, timeoutSeconds: Int) -> [ResolvedAddress]? {
+        if isIPLiteral(host) {
+            return resolveAddressesBlocking(host: host, port: port, numericOnly: true)
+        }
+
         final class ResultBox: @unchecked Sendable {
             var addresses: [ResolvedAddress]?
             let semaphore = DispatchSemaphore(value: 0)
@@ -70,16 +77,14 @@ enum TCPProbe {
 
         let box = ResultBox()
         let thread = Thread {
-            box.addresses = resolveAddressesBlocking(host: host, port: port)
+            box.addresses = resolveAddressesBlocking(host: host, port: port, numericOnly: false)
             box.semaphore.signal()
         }
         thread.name = "TCPProbe.resolve"
         thread.stackSize = 512 * 1024
         thread.start()
 
-        // Allow at least 2 s for DNS even when the connect timeout is 1 s;
-        // IP-literal targets resolve instantly either way (AI_NUMERICSERV +
-        // numeric host short-circuits inside getaddrinfo).
+        // Allow at least 2 s for DNS even when the connect timeout is 1 s.
         let resolverDeadline = DispatchTime.now() + max(2.0, Double(timeoutSeconds) * 2.0)
         guard box.semaphore.wait(timeout: resolverDeadline) == .success else {
             return nil
@@ -87,12 +92,21 @@ enum TCPProbe {
         return box.addresses
     }
 
-    private static func resolveAddressesBlocking(host: String, port: UInt16) -> [ResolvedAddress]? {
+    private static func isIPLiteral(_ host: String) -> Bool {
+        var v4 = in_addr()
+        if inet_pton(AF_INET, host, &v4) == 1 {
+            return true
+        }
+        var v6 = in6_addr()
+        return inet_pton(AF_INET6, host, &v6) == 1
+    }
+
+    private static func resolveAddressesBlocking(host: String, port: UInt16, numericOnly: Bool) -> [ResolvedAddress]? {
         // Build hints via memberwise-zero init and explicit field assignment:
         // the addrinfo struct declares its members in a different order on
         // Darwin and Glibc, so a positional initializer is not portable.
         var hints = addrinfo()
-        hints.ai_flags = AI_NUMERICSERV
+        hints.ai_flags = numericOnly ? (AI_NUMERICSERV | AI_NUMERICHOST) : AI_NUMERICSERV
         hints.ai_family = AF_UNSPEC
         #if canImport(Glibc)
         hints.ai_socktype = Int32(SOCK_STREAM.rawValue)

--- a/PingWarden/PingWarden/Core/TCPProbe.swift
+++ b/PingWarden/PingWarden/Core/TCPProbe.swift
@@ -4,29 +4,102 @@
 //
 //  Lightweight TCP connect latency probe used by dashboard and monitoring.
 //
+//  Pure POSIX sockets (no Network.framework) so the same source compiles on
+//  macOS and Linux — the SwiftPM test target exercises it on both. The
+//  connect wait uses poll(2) rather than select(2): poll is portable, has no
+//  FD_SETSIZE ceiling, and needs no fd_set bit manipulation.
+//
+//  Measurement semantics: the reported latency is the TCP handshake time of
+//  the successful attempt ONLY. DNS resolution time and failed connect
+//  attempts (e.g. an unroutable IPv6 address tried before the working IPv4
+//  one) are excluded — including them used to report a ~1010 ms "successful
+//  ping" on dual-stack hostnames, poisoning averages, jitter, spike events,
+//  and auto-select rankings.
+//
 
 import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
 
 enum TCPProbe {
+    /// A resolved socket address, copied out of the addrinfo list so it can
+    /// outlive freeaddrinfo() and cross the resolver-thread boundary.
+    private struct ResolvedAddress {
+        let family: Int32
+        let socktype: Int32
+        let proto: Int32
+        let addressBytes: [UInt8]
+    }
+
+    /// Measure TCP connect latency in milliseconds. Returns nil on failure
+    /// (resolution failure/timeout, or no address accepted the connection).
     static func measureLatency(host: String, port: UInt16, timeoutSeconds: Int = 1) -> Double? {
-        let startTime = Date()
-        guard connect(host: host, port: port, timeoutSeconds: timeoutSeconds) else {
+        guard let addresses = resolveAddresses(host: host, port: port, timeoutSeconds: timeoutSeconds),
+              !addresses.isEmpty else {
             return nil
         }
-        return Date().timeIntervalSince(startTime) * 1000.0
+
+        for address in addresses {
+            if let latencyMs = connectSingle(address, timeoutSeconds: timeoutSeconds) {
+                return latencyMs
+            }
+        }
+        return nil
     }
 
     static func connect(host: String, port: UInt16, timeoutSeconds: Int = 1) -> Bool {
-        var hints = addrinfo(
-            ai_flags: AI_NUMERICSERV,
-            ai_family: AF_UNSPEC,
-            ai_socktype: SOCK_STREAM,
-            ai_protocol: IPPROTO_TCP,
-            ai_addrlen: 0,
-            ai_canonname: nil,
-            ai_addr: nil,
-            ai_next: nil
-        )
+        measureLatency(host: host, port: port, timeoutSeconds: timeoutSeconds) != nil
+    }
+
+    // MARK: - Resolution
+
+    /// getaddrinfo has no timeout of its own — an unresponsive resolver can
+    /// block for ~30 s, which used to freeze the entire probe pipeline (the
+    /// serial probe queue skipped every subsequent tick behind the hung
+    /// call). Run it on a detached thread and give it a bounded window; on
+    /// timeout the probe reports failure and the orphaned thread finishes on
+    /// its own.
+    private static func resolveAddresses(host: String, port: UInt16, timeoutSeconds: Int) -> [ResolvedAddress]? {
+        final class ResultBox: @unchecked Sendable {
+            var addresses: [ResolvedAddress]?
+            let semaphore = DispatchSemaphore(value: 0)
+        }
+
+        let box = ResultBox()
+        let thread = Thread {
+            box.addresses = resolveAddressesBlocking(host: host, port: port)
+            box.semaphore.signal()
+        }
+        thread.name = "TCPProbe.resolve"
+        thread.stackSize = 512 * 1024
+        thread.start()
+
+        // Allow at least 2 s for DNS even when the connect timeout is 1 s;
+        // IP-literal targets resolve instantly either way (AI_NUMERICSERV +
+        // numeric host short-circuits inside getaddrinfo).
+        let resolverDeadline = DispatchTime.now() + max(2.0, Double(timeoutSeconds) * 2.0)
+        guard box.semaphore.wait(timeout: resolverDeadline) == .success else {
+            return nil
+        }
+        return box.addresses
+    }
+
+    private static func resolveAddressesBlocking(host: String, port: UInt16) -> [ResolvedAddress]? {
+        // Build hints via memberwise-zero init and explicit field assignment:
+        // the addrinfo struct declares its members in a different order on
+        // Darwin and Glibc, so a positional initializer is not portable.
+        var hints = addrinfo()
+        hints.ai_flags = AI_NUMERICSERV
+        hints.ai_family = AF_UNSPEC
+        #if canImport(Glibc)
+        hints.ai_socktype = Int32(SOCK_STREAM.rawValue)
+        #else
+        hints.ai_socktype = SOCK_STREAM
+        #endif
+        hints.ai_protocol = Int32(IPPROTO_TCP)
 
         var result: UnsafeMutablePointer<addrinfo>?
         let status = getaddrinfo(host, String(port), &hints, &result)
@@ -35,87 +108,104 @@ enum TCPProbe {
         // getaddrinfo() fails, so freeaddrinfo() must not be called on it.
         // On success the manpage guarantees a non-nil linked list.
         guard status == 0, let resolved = result else {
-            return false
+            return nil
         }
-
         defer { freeaddrinfo(resolved) }
 
+        var addresses: [ResolvedAddress] = []
         var current: UnsafeMutablePointer<addrinfo>? = resolved
-        while let addrInfo = current {
-            if connectSingle(addrInfo: addrInfo.pointee, timeoutSeconds: timeoutSeconds) {
-                return true
+        while let info = current {
+            if let addrPtr = info.pointee.ai_addr, info.pointee.ai_addrlen > 0 {
+                let byteCount = Int(info.pointee.ai_addrlen)
+                let bytes = UnsafeRawBufferPointer(start: UnsafeRawPointer(addrPtr), count: byteCount)
+                addresses.append(ResolvedAddress(
+                    family: info.pointee.ai_family,
+                    socktype: info.pointee.ai_socktype,
+                    proto: info.pointee.ai_protocol,
+                    addressBytes: Array(bytes)
+                ))
             }
-            current = addrInfo.pointee.ai_next
+            current = info.pointee.ai_next
         }
-        return false
+        return addresses
     }
 
-    private static func connectSingle(addrInfo: addrinfo, timeoutSeconds: Int) -> Bool {
-        let socketFD = socket(addrInfo.ai_family, addrInfo.ai_socktype, addrInfo.ai_protocol)
+    // MARK: - Connect
+
+    /// Attempt one address; returns the handshake latency in milliseconds on
+    /// success, nil on failure/timeout.
+    private static func connectSingle(_ resolved: ResolvedAddress, timeoutSeconds: Int) -> Double? {
+        let socketFD = socket(resolved.family, resolved.socktype, resolved.proto)
         guard socketFD >= 0 else {
-            return false
+            return nil
         }
         defer { close(socketFD) }
 
         let currentFlags = fcntl(socketFD, F_GETFL, 0)
         guard currentFlags >= 0,
               fcntl(socketFD, F_SETFL, currentFlags | O_NONBLOCK) >= 0 else {
-            return false
+            return nil
         }
 
-        let connectResult = Darwin.connect(socketFD, addrInfo.ai_addr, addrInfo.ai_addrlen)
+        let startTime = Date()
+        let connectResult = resolved.addressBytes.withUnsafeBytes { raw -> Int32 in
+            guard let base = raw.baseAddress else { return -1 }
+            let sockaddrPtr = base.assumingMemoryBound(to: sockaddr.self)
+            return systemConnect(socketFD, sockaddrPtr, socklen_t(raw.count))
+        }
         if connectResult == 0 {
-            return true
+            return elapsedMs(since: startTime)
         }
 
         if errno != EINPROGRESS {
-            return false
+            return nil
         }
 
-        var writeSet = fd_set()
-        fdZero(&writeSet)
-        guard fdSet(socketFD, set: &writeSet) else {
-            return false
-        }
-
-        var timeout = timeval(tv_sec: timeoutSeconds, tv_usec: 0)
-        let selectResult = select(socketFD + 1, nil, &writeSet, nil, &timeout)
-        guard selectResult > 0 else {
-            return false
+        // Wait for the socket to become writable (connect finished or failed),
+        // retrying on EINTR without extending the overall deadline.
+        var pollFD = pollfd(fd: socketFD, events: Int16(POLLOUT), revents: 0)
+        let deadline = Date().addingTimeInterval(TimeInterval(timeoutSeconds))
+        while true {
+            let remainingMs = Int32((deadline.timeIntervalSinceNow * 1000).rounded(.up))
+            guard remainingMs > 0 else {
+                return nil
+            }
+            let pollResult = poll(&pollFD, 1, remainingMs)
+            if pollResult > 0 {
+                break
+            }
+            if pollResult == 0 {
+                return nil  // Timed out
+            }
+            if errno != EINTR {
+                return nil
+            }
         }
 
         var socketError: Int32 = 0
         var errorLen = socklen_t(MemoryLayout<Int32>.size)
-        getsockopt(socketFD, SOL_SOCKET, SO_ERROR, &socketError, &errorLen)
-        return socketError == 0
+        guard getsockopt(socketFD, SOL_SOCKET, SO_ERROR, &socketError, &errorLen) == 0,
+              socketError == 0 else {
+            return nil
+        }
+        return elapsedMs(since: startTime)
     }
 
-    private static func fdZero(_ set: inout fd_set) {
-        set = fd_set()
+    private static func elapsedMs(since start: Date) -> Double {
+        Date().timeIntervalSince(start) * 1000.0
     }
 
-    private static func fdSet(_ fd: Int32, set: inout fd_set) -> Bool {
-        guard fd >= 0 else {
-            return false
-        }
-
-        let bitsPerWord = Int32(MemoryLayout<Int32>.size * 8)
-        let tupleByteCount = MemoryLayout.size(ofValue: set.fds_bits)
-        let wordCount = tupleByteCount / MemoryLayout<Int32>.size
-
-        let intOffset = Int(fd / bitsPerWord)
-        let bitOffset = Int(fd % bitsPerWord)
-
-        guard intOffset >= 0, intOffset < wordCount else {
-            return false
-        }
-
-        withUnsafeMutableBytes(of: &set.fds_bits) { rawPtr in
-            guard let baseAddress = rawPtr.baseAddress else { return }
-            let ptr = baseAddress.assumingMemoryBound(to: Int32.self)
-            let bitMask = Int32(bitPattern: UInt32(1) << UInt32(bitOffset))
-            ptr[intOffset] |= bitMask
-        }
-        return true
+    /// Platform-qualified connect(2). The enum's own `connect(host:port:)`
+    /// shadows the libc symbol, so the call must be disambiguated per platform.
+    private static func systemConnect(
+        _ fd: Int32,
+        _ addr: UnsafePointer<sockaddr>?,
+        _ len: socklen_t
+    ) -> Int32 {
+        #if canImport(Darwin)
+        return Darwin.connect(fd, addr, len)
+        #elseif canImport(Glibc)
+        return Glibc.connect(fd, addr, len)
+        #endif
     }
 }

--- a/PingWarden/PingWarden/Core/XPCReconnectPolicy.swift
+++ b/PingWarden/PingWarden/Core/XPCReconnectPolicy.swift
@@ -8,8 +8,15 @@
 import Foundation
 
 enum XPCReconnectPolicy {
+    /// Upper bound on the backoff so a large attempt number can never
+    /// produce a multi-day (or, past ~1024 attempts, infinite) delay that
+    /// effectively stops retrying.
+    static let maxDelaySeconds: TimeInterval = 30
+
     static func delayForAttempt(_ attempt: Int) -> TimeInterval {
         guard attempt > 0 else { return 0 }
-        return pow(2.0, Double(attempt - 1))
+        // Cap the exponent before pow() — pow(2, 1100) overflows to +inf.
+        let boundedAttempt = min(attempt, 16)
+        return min(pow(2.0, Double(boundedAttempt - 1)), maxDelaySeconds)
     }
 }

--- a/PingWarden/PingWarden/DashboardViewModel.swift
+++ b/PingWarden/PingWarden/DashboardViewModel.swift
@@ -32,14 +32,26 @@ class DashboardViewModel: ObservableObject {
         didSet {
             if !DashboardConfig.timeframeOptions.contains(selectedTimeframe) {
                 selectedTimeframe = 15
+                return
             }
+            refreshFilteredHistory()
         }
     }
     @Published private(set) var targets: [PingTarget] = []
     @Published var selectedTargetID: String = "" {
         didSet {
             guard selectedTargetID != oldValue else { return }
-            userDefaults.set(selectedTargetID, forKey: DashboardConfig.selectedTargetKey)
+            if !isApplyingProgrammaticSelection {
+                // An explicit user selection supersedes a saved target that
+                // is still waiting for its async source (gateway/GFN zones).
+                pendingSavedTargetID = nil
+            }
+            // Never overwrite the persisted selection with a temporary
+            // fallback while the saved target is still pending — otherwise a
+            // saved GFN zone (or gateway) never survives a relaunch.
+            if pendingSavedTargetID == nil {
+                userDefaults.set(selectedTargetID, forKey: DashboardConfig.selectedTargetKey)
+            }
             restartMonitoring()
 
             if selectedTarget?.source == .geforceNow {
@@ -71,6 +83,11 @@ class DashboardViewModel: ObservableObject {
     private var lastGFNRefreshDate: Date = .distantPast
     private var previousInterventionCount: Int = 0
     private var hasInitializedInterventionBaseline = false
+    /// Saved target id from a previous session whose source (local gateway,
+    /// GFN zone list) hasn't been resolved yet this session. Re-applied the
+    /// moment the async source delivers it.
+    private var pendingSavedTargetID: String?
+    private var isApplyingProgrammaticSelection = false
 
     private let userDefaults = UserDefaults.standard
     private let customTargetStore = CustomPingTargetStore(userDefaults: PingWardenPreferences.shared.defaults)
@@ -79,10 +96,40 @@ class DashboardViewModel: ObservableObject {
         targets.first { $0.id == selectedTargetID }
     }
 
-    /// Filtered ping history based on selected timeframe
-    var filteredHistory: [PingMonitor.PingResult] {
+    /// Filtered + downsampled ping history for the chart, memoized per
+    /// update. The chart body reads this several times per render; as a
+    /// computed property that meant 5+ O(n) filters over ~3900 samples every
+    /// second, and Swift Charts degrades sharply past ~1000 marks — burning
+    /// CPU exactly during the gaming sessions the app exists to protect.
+    @Published private(set) var filteredHistory: [PingMonitor.PingResult] = []
+
+    private static let maxChartPoints = 720
+
+    private func refreshFilteredHistory() {
         let cutoff = Date().addingTimeInterval(-TimeInterval(selectedTimeframe * 60))
-        return pingHistory.filter { $0.timestamp > cutoff && $0.success }
+        let windowed = pingHistory.filter { $0.timestamp > cutoff && $0.success }
+        filteredHistory = Self.downsample(windowed, maxCount: Self.maxChartPoints)
+    }
+
+    /// Uniform-stride downsampling that always keeps latency spikes
+    /// (>=100 ms) and the newest sample, so thinning the line never hides
+    /// the events the chart exists to show.
+    private static func downsample(_ points: [PingMonitor.PingResult], maxCount: Int) -> [PingMonitor.PingResult] {
+        guard points.count > maxCount else { return points }
+        let strideLength = Double(points.count) / Double(maxCount)
+        var kept: [PingMonitor.PingResult] = []
+        kept.reserveCapacity(maxCount + 16)
+        var nextIndex = 0.0
+        for (index, point) in points.enumerated() {
+            let onStride = Double(index) >= nextIndex
+            if onStride || point.latencyMs >= 100 || index == points.count - 1 {
+                kept.append(point)
+                if onStride {
+                    nextIndex += strideLength
+                }
+            }
+        }
+        return kept
     }
 
     var filteredTimelineEvents: [LatencyTimelineEvent] {
@@ -99,16 +146,21 @@ class DashboardViewModel: ObservableObject {
     init() {
         // Initialize with base targets (no local gateway yet — resolved async in start())
         customTargets = customTargetStore.load()
-        targets = Self.baseTargets(localGateway: nil) + Self.toPingTargets(customTargets)
+        targets = Self.dedupe(Self.baseTargets(localGateway: nil) + Self.toPingTargets(customTargets))
 
         if let savedInterval = userDefaults.object(forKey: DashboardConfig.updateIntervalKey) as? Double {
             updateInterval = sanitizedInterval(savedInterval)
         }
 
-        if let savedTargetID = normalizedSavedTargetID(userDefaults.string(forKey: DashboardConfig.selectedTargetKey)),
-           targets.contains(where: { $0.id == savedTargetID }) {
+        let savedTargetID = normalizedSavedTargetID(userDefaults.string(forKey: DashboardConfig.selectedTargetKey))
+        if let savedTargetID, targets.contains(where: { $0.id == savedTargetID }) {
             selectedTargetID = savedTargetID
         } else {
+            // The saved target may belong to an async source (gateway, GFN
+            // zone). Keep it pending and fall back for now; property
+            // observers don't fire during init, so the persisted key is
+            // not clobbered by the fallback.
+            pendingSavedTargetID = savedTargetID
             selectedTargetID = targets.first?.id ?? ""
         }
     }
@@ -175,14 +227,12 @@ class DashboardViewModel: ObservableObject {
             await MainActor.run { [weak self] in
                 guard let self, self.isStarted else { return }
                 let previousSelection = self.selectedTargetID
-                self.targets = Self.baseTargets(localGateway: gateway)
-                    + self.gfnTargets
-                    + Self.toPingTargets(self.customTargets)
-                if self.targets.contains(where: { $0.id == previousSelection }) {
-                    self.selectedTargetID = previousSelection
-                } else {
-                    self.selectedTargetID = self.targets.first(where: { $0.source == .local })?.id ?? self.targets.first?.id ?? ""
-                }
+                self.targets = Self.dedupe(
+                    Self.baseTargets(localGateway: gateway)
+                        + self.gfnTargets.sorted { $0.displayName < $1.displayName }
+                        + Self.toPingTargets(self.customTargets)
+                )
+                self.reapplySelectionAfterTargetsChanged(previousSelection: previousSelection)
             }
         }
 
@@ -232,6 +282,10 @@ class DashboardViewModel: ObservableObject {
         baselineSelectionTask = nil
         isRefreshingGFNServers = false
         isAutoSelectingTarget = false
+        // Re-baseline the intervention counter on the next start; otherwise
+        // interventions that happened while the dashboard was hidden get
+        // logged as one bogus timeline event timestamped at reopen.
+        hasInitializedInterventionBaseline = false
     }
 
     deinit {
@@ -256,6 +310,7 @@ class DashboardViewModel: ObservableObject {
         if clearHistory {
             pingMonitor.clearHistory()
             pingHistory.removeAll()
+            refreshFilteredHistory()
         }
 
         pingMonitor.start(server: target.host, port: target.port, interval: updateInterval)
@@ -267,6 +322,8 @@ class DashboardViewModel: ObservableObject {
         // Keep only a bit over one hour of data to support all dashboard windows.
         let cutoff = Date().addingTimeInterval(-DashboardConfig.historyRetentionSeconds)
         pingHistory.removeAll { $0.timestamp < cutoff }
+
+        refreshFilteredHistory()
 
         if result.success {
             let spikeThreshold = max(100.0, stats.averagePing * 2.0)
@@ -355,6 +412,10 @@ class DashboardViewModel: ObservableObject {
             await MainActor.run {
                 guard let self, !Task.isCancelled else { return }
                 self.isRefreshingGFNServers = false
+                // nil = fetch failed. Keep whatever zones we already have —
+                // wiping them would reset the user's selected GFN target and
+                // clear their chart history over a transient network blip.
+                guard let discoveredTargets else { return }
                 self.gfnTargets = discoveredTargets
                 self.rebuildTargets()
             }
@@ -369,20 +430,50 @@ class DashboardViewModel: ObservableObject {
         let sortedGFNTargets = gfnTargets.sorted { $0.displayName < $1.displayName }
         let customAsTargets = Self.toPingTargets(customTargets)
 
-        var deduplicatedTargets: [PingTarget] = []
+        targets = Self.dedupe(baseTargets + sortedGFNTargets + customAsTargets)
+        reapplySelectionAfterTargetsChanged(previousSelection: selectedTargetID)
+    }
+
+    /// Duplicate host:port combinations (e.g. a custom target that shadows a
+    /// built-in) would produce duplicate SwiftUI identifiers in the picker;
+    /// the first occurrence wins.
+    private static func dedupe(_ list: [PingTarget]) -> [PingTarget] {
+        var deduplicated: [PingTarget] = []
         var seenIDs = Set<String>()
+        for target in list where seenIDs.insert(target.id).inserted {
+            deduplicated.append(target)
+        }
+        return deduplicated
+    }
 
-        for target in baseTargets + sortedGFNTargets + customAsTargets {
-            if seenIDs.insert(target.id).inserted {
-                deduplicatedTargets.append(target)
+    /// Re-resolve the selection after the target list changed: a saved-but-
+    /// pending target wins the moment its source delivers it, then the
+    /// previous selection if still present, then the local-gateway/first
+    /// fallback.
+    private func reapplySelectionAfterTargetsChanged(previousSelection: String) {
+        if let pending = pendingSavedTargetID, targets.contains(where: { $0.id == pending }) {
+            pendingSavedTargetID = nil
+            applyProgrammaticSelection(pending)
+            return
+        }
+        if targets.contains(where: { $0.id == previousSelection }) {
+            if selectedTargetID != previousSelection {
+                applyProgrammaticSelection(previousSelection)
             }
+            return
         }
+        applyProgrammaticSelection(
+            targets.first(where: { $0.source == .local })?.id ?? targets.first?.id ?? ""
+        )
+    }
 
-        targets = deduplicatedTargets
-
-        if !targets.contains(where: { $0.id == selectedTargetID }) {
-            selectedTargetID = targets.first(where: { $0.source == .local })?.id ?? targets.first?.id ?? ""
-        }
+    /// Selection changes made by the model itself (fallbacks, restoring a
+    /// pending saved target) must not discard the pending saved target the
+    /// way an explicit user pick does.
+    private func applyProgrammaticSelection(_ id: String) {
+        isApplyingProgrammaticSelection = true
+        selectedTargetID = id
+        isApplyingProgrammaticSelection = false
     }
 
     private static func baseTargets(localGateway: String?) -> [PingTarget] {
@@ -551,6 +642,32 @@ class DashboardViewModel: ObservableObject {
         }
     }
 
+    /// Dedicated queue for the blocking baseline probes. Running them
+    /// directly inside task-group children would block Swift-concurrency
+    /// cooperative-pool threads for seconds (timeout × samples × targets),
+    /// starving every other async task in the app.
+    nonisolated private static let baselineProbeQueue = DispatchQueue(
+        label: "com.amesvt.pingwarden.baselineprobe",
+        qos: .utility,
+        attributes: .concurrent
+    )
+
+    nonisolated private static func measureLatencyOffPool(
+        host: String,
+        port: UInt16,
+        timeoutSeconds: Int
+    ) async -> Double? {
+        await withCheckedContinuation { continuation in
+            baselineProbeQueue.async {
+                continuation.resume(returning: TCPProbe.measureLatency(
+                    host: host,
+                    port: port,
+                    timeoutSeconds: timeoutSeconds
+                ))
+            }
+        }
+    }
+
     nonisolated private static func collectBaselineMeasurements(
         candidates: [PingTarget],
         sampleCount: Int
@@ -564,7 +681,7 @@ class DashboardViewModel: ObservableObject {
                             return nil
                         }
 
-                        if let latency = TCPProbe.measureLatency(
+                        if let latency = await measureLatencyOffPool(
                             host: target.host,
                             port: target.port,
                             timeoutSeconds: DashboardConfig.baselineProbeTimeoutSeconds

--- a/PingWarden/PingWarden/DashboardViewModel.swift
+++ b/PingWarden/PingWarden/DashboardViewModel.swift
@@ -226,13 +226,7 @@ class DashboardViewModel: ObservableObject {
             guard let gateway else { return }
             await MainActor.run { [weak self] in
                 guard let self, self.isStarted else { return }
-                let previousSelection = self.selectedTargetID
-                self.targets = Self.dedupe(
-                    Self.baseTargets(localGateway: gateway)
-                        + self.gfnTargets.sorted { $0.displayName < $1.displayName }
-                        + Self.toPingTargets(self.customTargets)
-                )
-                self.reapplySelectionAfterTargetsChanged(previousSelection: previousSelection)
+                self.rebuildTargets(localGateway: gateway)
             }
         }
 
@@ -422,10 +416,13 @@ class DashboardViewModel: ObservableObject {
         }
     }
 
-    private func rebuildTargets() {
-        // Use cached gateway from existing targets — do NOT call NetworkGatewayResolver
-        // here since this runs on @MainActor and the resolver spawns a blocking Process.
-        let gatewayHost = targets.first(where: { $0.source == .local })?.host
+    /// Rebuild the full target list from all sources. Pass `localGateway`
+    /// when a freshly resolved gateway is in hand; otherwise the gateway
+    /// cached in the existing targets is reused — do NOT call
+    /// NetworkGatewayResolver here since this runs on @MainActor and the
+    /// resolver spawns a blocking Process.
+    private func rebuildTargets(localGateway: String? = nil) {
+        let gatewayHost = localGateway ?? targets.first(where: { $0.source == .local })?.host
         let baseTargets = Self.baseTargets(localGateway: gatewayHost)
         let sortedGFNTargets = gfnTargets.sorted { $0.displayName < $1.displayName }
         let customAsTargets = Self.toPingTargets(customTargets)
@@ -672,8 +669,13 @@ class DashboardViewModel: ObservableObject {
         candidates: [PingTarget],
         sampleCount: Int
     ) async -> [String: [Double]] {
-        await withTaskGroup(of: (String, [Double])?.self) { group in
-            for target in candidates {
+        // Bound the fan-out: each candidate parks a blocking probe on
+        // baselineProbeQueue, and an unbounded group over ~36 targets would
+        // drive GCD to spawn dozens of overcommit threads in one burst.
+        let maxConcurrentProbes = 8
+
+        return await withTaskGroup(of: (String, [Double])?.self) { group in
+            func addProbeTask(for target: PingTarget) {
                 group.addTask {
                     var samples: [Double] = []
                     for sampleIndex in 0..<sampleCount {
@@ -699,8 +701,18 @@ class DashboardViewModel: ObservableObject {
                 }
             }
 
+            var nextCandidateIndex = 0
+            while nextCandidateIndex < candidates.count && nextCandidateIndex < maxConcurrentProbes {
+                addProbeTask(for: candidates[nextCandidateIndex])
+                nextCandidateIndex += 1
+            }
+
             var measurements: [String: [Double]] = [:]
             for await result in group {
+                if nextCandidateIndex < candidates.count {
+                    addProbeTask(for: candidates[nextCandidateIndex])
+                    nextCandidateIndex += 1
+                }
                 guard let (targetID, samples) = result else { continue }
                 measurements[targetID] = samples
             }

--- a/PingWarden/PingWarden/DiagnosticsExporter.swift
+++ b/PingWarden/PingWarden/DiagnosticsExporter.swift
@@ -15,6 +15,16 @@ enum DiagnosticsExporter {
     }
 
     static func exportSnapshot() -> ExportResult? {
+        // Both getInterventionCount and performHealthCheck below use
+        // semaphore waits that would deadlock/stall the main thread. Enforce
+        // the background-queue contract up front and in Release builds too
+        // (assert() compiles out and would let a future main-thread call
+        // site hang the UI).
+        guard !Thread.isMainThread else {
+            assertionFailure("exportSnapshot must not be called on the main thread")
+            return nil
+        }
+
         let monitor = PingWardenMonitor.shared
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
@@ -53,10 +63,6 @@ enum DiagnosticsExporter {
             registrationStatus = "unknown"
         }
 
-        // Both getInterventionCount (above) and performHealthCheck use semaphore
-        // waits that would deadlock the main thread. The sole call site already
-        // dispatches to a background queue, so assert that contract here.
-        assert(!Thread.isMainThread, "exportSnapshot must not be called on the main thread")
         let health = monitor.performHealthCheck()
         let awdlStatus = monitor.currentAWDLInterfaceStatus()
 
@@ -100,15 +106,21 @@ enum DiagnosticsExporter {
         """
 
         let desktop = FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first
-        let destinationDir = desktop ?? FileManager.default.temporaryDirectory
         let filename = "PingWarden-Diagnostics-\(fileTimestamp).txt"
-        let fileURL = destinationDir.appendingPathComponent(filename)
 
-        do {
-            try diagnostics.write(to: fileURL, atomically: true, encoding: .utf8)
-            return ExportResult(fileURL: fileURL, contents: diagnostics)
-        } catch {
-            return nil
+        // Desktop writes can fail (TCC denial, iCloud-evicted or read-only
+        // Desktop); fall back to the temporary directory rather than
+        // reporting a generic failure.
+        let candidateDirs = [desktop, FileManager.default.temporaryDirectory].compactMap { $0 }
+        for destinationDir in candidateDirs {
+            let fileURL = destinationDir.appendingPathComponent(filename)
+            do {
+                try diagnostics.write(to: fileURL, atomically: true, encoding: .utf8)
+                return ExportResult(fileURL: fileURL, contents: diagnostics)
+            } catch {
+                continue
+            }
         }
+        return nil
     }
 }

--- a/PingWarden/PingWarden/GeForceNOWDiscovery.swift
+++ b/PingWarden/PingWarden/GeForceNOWDiscovery.swift
@@ -20,8 +20,13 @@ enum GeForceNOWDiscovery {
         let name: String
     }
 
-    static func fetchTargets() async -> [PingTarget] {
-        guard let endpoint else { return [] }
+    /// Returns the discovered zone targets, or `nil` when the fetch failed
+    /// (network error, non-2xx, decode failure). `nil` is distinct from a
+    /// successful-but-empty response so callers can keep previously
+    /// discovered zones on a transient failure instead of wiping them —
+    /// which would silently reset the user's selected GFN target.
+    static func fetchTargets() async -> [PingTarget]? {
+        guard let endpoint else { return nil }
 
         var request = URLRequest(url: endpoint)
         request.timeoutInterval = 8
@@ -30,7 +35,7 @@ enum GeForceNOWDiscovery {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let httpResponse = response as? HTTPURLResponse,
                   (200...299).contains(httpResponse.statusCode) else {
-                return []
+                return nil
             }
 
             let payload = try JSONDecoder().decode(ComponentsResponse.self, from: data)
@@ -45,7 +50,7 @@ enum GeForceNOWDiscovery {
                 )
             }
         } catch {
-            return []
+            return nil
         }
     }
 

--- a/PingWarden/PingWarden/Info.plist
+++ b/PingWarden/PingWarden/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.3</string>
+	<string>2.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.4.3</string>
+	<string>2.5.0</string>
 	<key>GCSupportsControllerUserInteraction</key>
 	<false/>
 	<key>LSMinimumSystemVersion</key>

--- a/PingWarden/PingWarden/PingMonitor.swift
+++ b/PingWarden/PingWarden/PingMonitor.swift
@@ -92,7 +92,10 @@ class PingMonitor: @unchecked Sendable {
     
     var currentPing: TimeInterval? {
         withHistoryLock {
-            history.last?.latency
+            // Failed probes store the timeout as their latency; reporting
+            // that as "current ping" would show e.g. 1000 ms instead of
+            // signaling loss. Surface the last *successful* measurement.
+            history.last(where: { $0.success })?.latency
         }
     }
     
@@ -102,16 +105,20 @@ class PingMonitor: @unchecked Sendable {
     
     // MARK: - Public Methods
     
-    /// Start monitoring with specified server and interval
+    /// Start monitoring with specified server and interval.
+    /// A start while already running is a no-op — callers must stop() first
+    /// to retarget. (Config used to be written before this guard, silently
+    /// retargeting the running monitor's next tick and mixing two hosts'
+    /// samples in one history window.)
     func start(server: String? = nil, port: UInt16? = nil, interval: TimeInterval? = nil) {
+        guard !isMonitoring else {
+            log.warning("Ping monitor already running - ignoring start (stop() first to retarget)")
+            return
+        }
+
         if let server = server { self.server = server }
         if let port = port { self.port = port }
         if let interval = interval { self.interval = interval }
-        
-        guard !isMonitoring else {
-            log.warning("Ping monitor already running")
-            return
-        }
         
         log.info("Starting ping monitor: \(self.server):\(self.port) every \(self.interval)s")
         let sessionID = beginSession()

--- a/PingWarden/PingWarden/PingWardenApp.swift
+++ b/PingWarden/PingWarden/PingWardenApp.swift
@@ -83,6 +83,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
 
     private var updaterController: SPUStandardUpdaterController?
     private var updaterStartupError: Error?
+    private var updaterHasStarted = false
     
     private var monitoringObserver: NSObjectProtocol?
     private var controlCenterObserver: NSObjectProtocol?
@@ -119,8 +120,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
         // Clear any cached Settings window state from prior builds that may have
         // injected fullSizeContentView or other window customizations via onAppear.
         // The SwiftUI Settings scene persists window frames under these keys.
+        // Exclude our own AppKit settings window's autosave frame
+        // ("PingWardenSettings") — deleting it every launch would throw away
+        // the user's window size/position.
         for key in UserDefaults.standard.dictionaryRepresentation().keys {
-            if key.contains("NSWindow Frame") && key.contains("Settings") {
+            if key.contains("NSWindow Frame") && key.contains("Settings") && !key.contains("PingWardenSettings") {
                 UserDefaults.standard.removeObject(forKey: key)
             }
         }
@@ -150,8 +154,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
         // Observe monitor state changes
         monitorStateObserverToken = monitor.addStateObserver { [weak self] in
             Task { @MainActor in
-                self?.updateMenuBarIcon()
-                self?.updateMenuItem()
+                guard let self else { return }
+                self.updateMenuBarIcon()
+                self.updateMenuItem()
+                // If Sparkle was deferred during first-run setup, start it as
+                // soon as the helper registration completes — otherwise
+                // automatic update checks stay silently disabled all session.
+                if PingWardenMonitor.shared.isHelperRegistered {
+                    self.startUpdaterIfNeeded()
+                }
             }
         }
 
@@ -174,9 +185,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
             }
         } else {
             log.info("Helper already registered")
-            if PingWardenPreferences.shared.isMonitoringEnabled && !monitor.isMonitoringActive {
-                monitor.startMonitoring()
-            }
+            // Reconcile both directions at startup: start if the user wants
+            // protection and it isn't running, but also stop if a widget/
+            // Shortcuts toggle turned it off while the app wasn't running.
+            handleMonitoringStateChange()
             // Only consider the donation prompt once setup is finished. Brand
             // new users see the welcome flow on their first launch and the
             // donation ask on the next one — asking before they've used the
@@ -288,7 +300,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
         quickPauseTimer = nil
 
         if PingWardenMonitor.shared.isMonitoringActive {
-            PingWardenMonitor.shared.stopMonitoring()
+            // Transient stop: quitting must not flip the user's preference
+            // off, or the launch-time restore would never re-enable
+            // protection after a normal quit + relaunch.
+            PingWardenMonitor.shared.stopMonitoring(persistUserPreference: false)
         }
 
         if let token = monitorStateObserverToken {
@@ -330,6 +345,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
         let aboutVisible = aboutWindow?.isVisible ?? false
         let welcomeVisible = welcomeWindow?.isVisible ?? false
         let donationVisible = donationWindow?.isVisible ?? false
+
+        // Lockout invariant (H2): never hide the dock icon while Control
+        // Center mode has the menu bar icon removed. Without this, unchecking
+        // "Show Dock Icon" after enabling Control Center mode leaves no way
+        // into the app except re-launching from Finder — and the state
+        // persists across launches. (Checked against the preference, not
+        // `statusItem == nil`, because this also runs at launch before
+        // setupMenuBar() when statusItem is legitimately still nil.)
+        if PingWardenPreferences.shared.controlCenterWidgetEnabled,
+           !PingWardenPreferences.shared.showDockIcon {
+            log.info("Menu bar icon is hidden (Control Center mode) — forcing dock icon on to prevent lockout")
+            PingWardenPreferences.shared.showDockIcon = true
+            return // the preference setter re-triggers this method via its notification
+        }
 
         if PingWardenPreferences.shared.showDockIcon || settingsVisible || aboutVisible || welcomeVisible || donationVisible {
             NSApp.setActivationPolicy(.regular)
@@ -417,6 +446,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
             )
             gameModeSnapshot = nil
 
+            // A quick pause the user started *during* Game Mode takes
+            // priority: honor it instead of force-resuming blocking from the
+            // pre-game snapshot.
+            if let currentPause = quickPauseUntil, currentPause > Date(),
+               currentPause != snapshot.quickPauseUntil {
+                log.info("Game Mode inactive - honoring quick pause started during Game Mode")
+                if PingWardenMonitor.shared.isMonitoringActive {
+                    PingWardenMonitor.shared.stopMonitoring(persistUserPreference: false)
+                }
+                scheduleQuickPauseTimer()
+                updateMenuItem()
+                return
+            }
+
             if let pauseUntil = snapshot.quickPauseUntil, pauseUntil > Date() {
                 log.info("Game Mode inactive - restoring paused state")
                 quickPauseUntil = pauseUntil
@@ -425,14 +468,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
                 scheduleQuickPauseTimer()
                 updateMenuItem()
                 return
-            } else {
-                clearQuickPauseState()
             }
 
-            if snapshot.wasMonitoringActive && !PingWardenMonitor.shared.isMonitoringActive {
+            clearQuickPauseState()
+
+            // If a pre-game pause expired while the game was running, restore
+            // from the user's persistent intent — the runtime state captured
+            // at game start ("off", because paused) is stale by now.
+            let shouldMonitor = snapshot.quickPauseUntil != nil
+                ? snapshot.userIntentMonitoringEnabled
+                : snapshot.wasMonitoringActive
+
+            if shouldMonitor && !PingWardenMonitor.shared.isMonitoringActive {
                 log.info("Game Mode inactive - restoring AWDL blocking state to enabled")
                 PingWardenMonitor.shared.startMonitoring(persistUserPreference: false)
-            } else if !snapshot.wasMonitoringActive && PingWardenMonitor.shared.isMonitoringActive {
+            } else if !shouldMonitor && PingWardenMonitor.shared.isMonitoringActive {
                 log.info("Game Mode inactive - restoring AWDL blocking state to disabled")
                 PingWardenMonitor.shared.stopMonitoring(persistUserPreference: false)
             }
@@ -562,6 +612,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
         updateMenuBarIcon()
         statusMenu = NSMenu()
         statusMenu?.delegate = self
+        // Manual isEnabled control for the pause/resume items: with
+        // autoenablesItems left on, AppKit re-enables any item whose target
+        // responds to its action every time the menu opens, overriding the
+        // assignments in updateQuickActionMenuItems().
+        statusMenu?.autoenablesItems = false
 
         // Toggle item
         let toggleItem = NSMenuItem(
@@ -745,8 +800,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
         window.toolbarStyle = .unified
         window.titlebarAppearsTransparent = false
         window.toolbar?.showsBaselineSeparator = false
-        window.setFrameAutosaveName("PingWardenSettings")
+        // Center first, then attach the autosave name: setFrameAutosaveName
+        // restores any saved frame, so the restored position must not be
+        // clobbered by a subsequent center().
         window.center()
+        window.setFrameAutosaveName("PingWardenSettings")
 
         settingsWindow = window
         window.makeKeyAndOrderFront(nil)
@@ -797,13 +855,19 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
         updaterController?.updater.checkForUpdates()
     }
 
+    @discardableResult
     private func startUpdaterIfNeeded() -> Bool {
         guard let updater = updaterController?.updater else {
             return false
         }
-        
+
+        if updaterHasStarted {
+            return true
+        }
+
         do {
             try updater.start()
+            updaterHasStarted = true
             updaterStartupError = nil
             return true
         } catch {
@@ -1048,6 +1112,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
             Task { @MainActor in
                 self?.resumeMonitoringAfterQuickPause()
             }
+        }
+        // .common mode so the auto-resume still fires while the status menu
+        // is held open or a modal alert is running.
+        if let quickPauseTimer {
+            RunLoop.main.add(quickPauseTimer, forMode: .common)
         }
     }
 
@@ -2455,10 +2524,16 @@ final class GameModeDetector: @unchecked Sendable {
             return false
         }
 
-        // Check LSApplicationCategoryType for game category
+        // Check LSApplicationCategoryType for game category. The generic
+        // category is "public.app-category.games", but most titles declare a
+        // subcategory like "public.app-category.action-games" or
+        // "public.app-category.role-playing-games" — those end in "-games"
+        // and do NOT share the generic prefix, so match both shapes.
         if let categoryType = infoPlist["LSApplicationCategoryType"] as? String {
-            if categoryType.hasPrefix("public.app-category.games") {
-                log.debug("App \(bundleURL.lastPathComponent) has game category")
+            let isGameCategory = categoryType == "public.app-category.games" ||
+                (categoryType.hasPrefix("public.app-category.") && categoryType.hasSuffix("-games"))
+            if isGameCategory {
+                log.debug("App \(bundleURL.lastPathComponent) has game category (\(categoryType))")
                 return true
             }
         }

--- a/PingWarden/PingWarden/PingWardenApp.swift
+++ b/PingWarden/PingWarden/PingWardenApp.swift
@@ -357,7 +357,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate, NSMenuDele
            !PingWardenPreferences.shared.showDockIcon {
             log.info("Menu bar icon is hidden (Control Center mode) — forcing dock icon on to prevent lockout")
             PingWardenPreferences.shared.showDockIcon = true
-            return // the preference setter re-triggers this method via its notification
+            // Deliberately fall through (no early return): at launch this
+            // runs before the dockIconVisibilityChanged observer exists, so
+            // relying on the setter's notification to re-enter would leave
+            // the activation policy unset for the whole session.
         }
 
         if PingWardenPreferences.shared.showDockIcon || settingsVisible || aboutVisible || welcomeVisible || donationVisible {

--- a/PingWarden/PingWarden/PingWardenMonitor.swift
+++ b/PingWarden/PingWarden/PingWardenMonitor.swift
@@ -143,11 +143,16 @@ class PingWardenMonitor: @unchecked Sendable {
     /// Thread-safe registry of state-change observer callbacks.
     private let stateObservers = StateObserverRegistry()
 
-    /// Timer for polling registration status
+    /// Timer for polling registration status (main-thread confined)
     private var registrationTimer: Timer?
 
-    /// Timer for registration timeout
+    /// Timer for registration timeout (main-thread confined)
     private var registrationTimeoutTimer: Timer?
+
+    /// Completion of the in-flight registration poll (main-thread confined).
+    /// Held so a superseding poll can still deliver `false` to the previous
+    /// caller — dropping it silently would wedge `isRegisteringHelper`.
+    private var pendingRegistrationCompletion: (@Sendable (Bool) -> Void)?
 
     private init() {
         log.info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -349,7 +354,7 @@ class PingWardenMonitor: @unchecked Sendable {
         }
 
         // Ensure XPC connection; connectXPC() resets the retry counter
-        // internally on successful activation.
+        // internally once the helper answers a validation ping.
         if xpcConnection == nil {
             connectXPC()
         }
@@ -676,15 +681,17 @@ class PingWardenMonitor: @unchecked Sendable {
 
         previousConnection?.invalidate()
 
-        // Reset retry count on successful activation
-        xpcRetryCount = 0
-
         log.info("XPC connection activated")
 
         // Validate connection asynchronously to avoid blocking UI paths.
+        // The retry counter is reset only here, once the helper has actually
+        // answered — activate() succeeding locally proves nothing about the
+        // daemon. Resetting after activate() would let a dead helper produce
+        // an infinite reconnect loop that never trips the max-retry cap.
         validateXPCConnection { [weak self] isValid in
             guard let self else { return }
             if isValid {
+                self.xpcRetryCount = 0
                 self.reassertMonitoringStateIfNeeded()
             }
         }
@@ -741,6 +748,12 @@ class PingWardenMonitor: @unchecked Sendable {
         proxy.setAWDLEnabled(false, reply: { [weak self] success in
             guard let monitor = self else { return }
             DispatchQueue.main.async {
+                // A stopMonitoring() may have raced the reassert; don't
+                // stamp "protection on" state over the user's fresh stop.
+                guard monitor.isMonitoring else {
+                    log.info("Skipping reassert completion: monitoring was stopped meanwhile")
+                    return
+                }
                 if success {
                     PingWardenPreferences.shared.effectiveMonitoringEnabled = true
                     PingWardenPreferences.shared.lastKnownState = "down"
@@ -788,9 +801,18 @@ class PingWardenMonitor: @unchecked Sendable {
             return
         }
         _isHandlingInvalidation = true
+        let abandonedConnection = _xpcConnection
         _xpcConnection = nil
         let wasMonitoring = _isMonitoring
         stateLock.unlock()
+
+        // When this path is reached from a proxy error handler (not the
+        // connection's own invalidationHandler), the connection object is
+        // still live in the XPC runtime. Invalidate it explicitly or it —
+        // and its mach resources and handler blocks — leak for the app's
+        // lifetime. invalidate() is an idempotent no-op on an
+        // already-invalidated connection.
+        abandonedConnection?.invalidate()
 
         if wasMonitoring {
             PingWardenPreferences.shared.effectiveMonitoringEnabled = false
@@ -854,26 +876,32 @@ class PingWardenMonitor: @unchecked Sendable {
 
     // MARK: - Registration Polling
 
-    /// Poll for registration status change with timeout
+    /// Poll for registration status change with timeout.
+    /// Timer state and the pending completion are main-thread confined:
+    /// callers can reach this from any thread (the singleton's init runs on
+    /// whichever thread first touches `shared`), and a Timer scheduled on a
+    /// background thread's never-spun run loop would simply never fire.
     private func startPollingForRegistration(completion: (@Sendable (Bool) -> Void)?) {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in
+                self?.startPollingForRegistration(completion: completion)
+            }
+            return
+        }
+
         log.debug("Starting registration polling (timeout: \(self.registrationTimeoutSeconds)s)...")
 
-        // Cancel any existing timers
-        registrationTimer?.invalidate()
-        registrationTimeoutTimer?.invalidate()
+        // A superseded poll must still deliver its completion — callers
+        // (e.g. startMonitoring's isRegisteringHelper flag) wait on it.
+        finishRegistrationPolling(success: false, reason: "superseded by a new registration poll")
+        pendingRegistrationCompletion = completion
 
         // Set up timeout timer
         registrationTimeoutTimer = Timer.scheduledTimer(withTimeInterval: registrationTimeoutSeconds, repeats: false) { [weak self] _ in
             guard let self = self else { return }
             log.warning("Registration polling timed out after \(self.registrationTimeoutSeconds)s")
-            self.registrationTimer?.invalidate()
-            self.registrationTimer = nil
-            self.registrationTimeoutTimer = nil
-
-            DispatchQueue.main.async {
-                self.showError("Registration timed out.\n\nPlease approve the helper in System Settings → Login Items and try again.")
-            }
-            completion?(false)
+            self.showError("Registration timed out.\n\nPlease approve the helper in System Settings → Login Items and try again.")
+            self.finishRegistrationPolling(success: false, reason: "timed out")
         }
 
         // Set up polling timer
@@ -888,21 +916,13 @@ class PingWardenMonitor: @unchecked Sendable {
 
             switch status {
             case .enabled:
-                timer.invalidate()
-                self.registrationTimer = nil
-                self.registrationTimeoutTimer?.invalidate()
-                self.registrationTimeoutTimer = nil
                 log.info("✅ Helper registration approved")
                 self.connectXPC()
-                completion?(true)
+                self.finishRegistrationPolling(success: true, reason: "approved")
 
             case .notRegistered:
-                timer.invalidate()
-                self.registrationTimer = nil
-                self.registrationTimeoutTimer?.invalidate()
-                self.registrationTimeoutTimer = nil
                 log.info("❌ Helper registration denied")
-                completion?(false)
+                self.finishRegistrationPolling(success: false, reason: "denied")
 
             case .requiresApproval, .notFound:
                 // Keep polling
@@ -912,6 +932,21 @@ class PingWardenMonitor: @unchecked Sendable {
                 break
             }
         }
+    }
+
+    /// Tear down the polling timers and deliver the pending completion
+    /// exactly once. Main-thread only.
+    private func finishRegistrationPolling(success: Bool, reason: String) {
+        dispatchPrecondition(condition: .onQueue(.main))
+        registrationTimer?.invalidate()
+        registrationTimer = nil
+        registrationTimeoutTimer?.invalidate()
+        registrationTimeoutTimer = nil
+
+        guard let completion = pendingRegistrationCompletion else { return }
+        pendingRegistrationCompletion = nil
+        log.debug("Registration polling finished (\(reason, privacy: .public))")
+        completion(success)
     }
 
     // MARK: - Helper Methods

--- a/PingWarden/PingWarden/PingWardenPreferences.swift
+++ b/PingWarden/PingWarden/PingWardenPreferences.swift
@@ -65,6 +65,7 @@ final class PingWardenPreferences: @unchecked Sendable {
                 userInfo: nil,
                 deliverImmediately: true
             )
+            ControlCenterSupport.reloadPingProtectionControl()
         }
     }
 
@@ -81,6 +82,7 @@ final class PingWardenPreferences: @unchecked Sendable {
                 deliverImmediately: true
             )
             NotificationCenter.default.post(name: .awdlMonitorStateChanged, object: nil)
+            ControlCenterSupport.reloadPingProtectionControl()
         }
     }
 

--- a/PingWarden/PingWarden/QuarantineHelper.swift
+++ b/PingWarden/PingWarden/QuarantineHelper.swift
@@ -65,12 +65,13 @@ struct QuarantineHelper {
         }
     }
 
+    /// Main-thread only (presents modal alerts).
     private static func presentQuarantineHelpAlert() {
         // Build the remediation command from the actual bundle location —
         // the app may be running from ~/Downloads or a renamed bundle.
         let removalCommand = "xattr -cr \"\(Bundle.main.bundlePath)\""
 
-        DispatchQueue.main.async {
+        do {
             let alert = NSAlert()
             alert.messageText = "First Time Setup"
             alert.informativeText = """

--- a/PingWarden/PingWarden/QuarantineHelper.swift
+++ b/PingWarden/PingWarden/QuarantineHelper.swift
@@ -51,11 +51,25 @@ struct QuarantineHelper {
     
     /// Show helpful dialog if app is quarantined
     static func showQuarantineHelpIfNeeded() {
-        // Only show if quarantined and not properly signed (most users)
-        guard isQuarantined() && !isProperlyCodeSigned() else {
-            return
+        // Run the checks off the main thread: SecStaticCodeCheckValidity
+        // hashes the whole bundle (including Sparkle.framework) on the
+        // quarantined first-run path, which would stall launch for seconds.
+        DispatchQueue.global(qos: .utility).async {
+            // Only show if quarantined and not properly signed (most users)
+            guard isQuarantined() && !isProperlyCodeSigned() else {
+                return
+            }
+            DispatchQueue.main.async {
+                presentQuarantineHelpAlert()
+            }
         }
-        
+    }
+
+    private static func presentQuarantineHelpAlert() {
+        // Build the remediation command from the actual bundle location —
+        // the app may be running from ~/Downloads or a renamed bundle.
+        let removalCommand = "xattr -cr \"\(Bundle.main.bundlePath)\""
+
         DispatchQueue.main.async {
             let alert = NSAlert()
             alert.messageText = "First Time Setup"
@@ -66,9 +80,9 @@ struct QuarantineHelper {
             
             1. Opening Terminal
             2. Running this command:
-            
-            xattr -cr "/Applications/Ping Warden.app"
-            
+
+            \(removalCommand)
+
             Then relaunch the app.
             
             This only needs to be done once!
@@ -84,7 +98,7 @@ struct QuarantineHelper {
             case .alertFirstButtonReturn: // Copy Command
                 let pasteboard = NSPasteboard.general
                 pasteboard.clearContents()
-                pasteboard.setString("xattr -cr \"/Applications/Ping Warden.app\"", forType: .string)
+                pasteboard.setString(removalCommand, forType: .string)
                 
                 let confirmAlert = NSAlert()
                 confirmAlert.messageText = "Command Copied!"

--- a/PingWarden/PingWarden/notarize.sh
+++ b/PingWarden/PingWarden/notarize.sh
@@ -291,43 +291,42 @@ echo -e "${GREEN}✓${NC} Ticket stapled successfully"
 echo ""
 echo "Creating notarized DMG..."
 if [ ! -f "$CREATE_DMG_SCRIPT" ]; then
-    # Previously this block was silently skipped, printing "Notarization
+    # Previously this section was silently skipped, printing "Notarization
     # Complete!" and exiting 0 with no DMG produced.
     echo -e "${RED}Error: create-dmg.sh not found at $CREATE_DMG_SCRIPT${NC}"
     exit 1
 fi
-if [ -f "$CREATE_DMG_SCRIPT" ]; then
-    "$CREATE_DMG_SCRIPT" "$VERSION" "$STAGED_APP_PATH"
 
-    if [ -f "$DMG_NAME" ]; then
-        echo ""
-        echo "Signing DMG with Developer ID..."
-        codesign -f -s "$APP_DEVELOPER_IDENTITY" --timestamp "$DMG_NAME"
-        codesign --verify --verbose=2 "$DMG_NAME"
-        echo -e "${GREEN}✓${NC} DMG code signature valid"
+"$CREATE_DMG_SCRIPT" "$VERSION" "$STAGED_APP_PATH"
 
-        echo ""
-        echo "Submitting DMG to Apple for notarization..."
-        DMG_SUBMIT_OUTPUT=$(xcrun notarytool submit "$DMG_NAME" \
-            "${NOTARYTOOL_ARGS[@]}" \
-            --wait 2>&1) || true
-        echo "$DMG_SUBMIT_OUTPUT"
-        
-        if ! echo "$DMG_SUBMIT_OUTPUT" | grep -q "status: Accepted"; then
-            echo -e "${RED}✗ DMG notarization failed${NC}"
-            exit 1
-        fi
-        
-        echo -e "${GREEN}✓${NC} DMG notarization successful"
-        echo ""
-        echo "Stapling DMG..."
-        xcrun stapler staple "$DMG_NAME"
-        echo -e "${GREEN}✓${NC} DMG stapled"
-    else
-        echo -e "${RED}Error: create-dmg.sh ran but $DMG_NAME was not produced${NC}"
-        exit 1
-    fi
+if [ ! -f "$DMG_NAME" ]; then
+    echo -e "${RED}Error: create-dmg.sh ran but $DMG_NAME was not produced${NC}"
+    exit 1
 fi
+
+echo ""
+echo "Signing DMG with Developer ID..."
+codesign -f -s "$APP_DEVELOPER_IDENTITY" --timestamp "$DMG_NAME"
+codesign --verify --verbose=2 "$DMG_NAME"
+echo -e "${GREEN}✓${NC} DMG code signature valid"
+
+echo ""
+echo "Submitting DMG to Apple for notarization..."
+DMG_SUBMIT_OUTPUT=$(xcrun notarytool submit "$DMG_NAME" \
+    "${NOTARYTOOL_ARGS[@]}" \
+    --wait 2>&1) || true
+echo "$DMG_SUBMIT_OUTPUT"
+
+if ! echo "$DMG_SUBMIT_OUTPUT" | grep -q "status: Accepted"; then
+    echo -e "${RED}✗ DMG notarization failed${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✓${NC} DMG notarization successful"
+echo ""
+echo "Stapling DMG..."
+xcrun stapler staple "$DMG_NAME"
+echo -e "${GREEN}✓${NC} DMG stapled"
 
 # Summary
 echo ""

--- a/PingWarden/PingWarden/notarize.sh
+++ b/PingWarden/PingWarden/notarize.sh
@@ -18,7 +18,13 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Configuration
 APP_NAME="Ping Warden"
-VERSION="${1:-2.2.1}"
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    echo "Error: version argument is required (a stale default here once produced" >&2
+    echo "DMGs whose filename didn't match their contents)." >&2
+    echo "Usage: ./notarize.sh <version>" >&2
+    exit 1
+fi
 BUNDLE_ID="com.amesvt.pingwarden"
 KEYCHAIN_PROFILE="${KEYCHAIN_PROFILE:-notarytool-profile}"  # Must match setup in NOTARIZATION_GUIDE.md
 TEAM_ID="PV3W52NDZ3"  # Apple Developer Team ID
@@ -49,6 +55,15 @@ APP_ENTITLEMENTS="$PROJECT_ROOT/PingWarden/PingWarden.entitlements"
 WIDGET_ENTITLEMENTS="$PROJECT_ROOT/PingWardenWidget/PingWardenWidget.entitlements"
 STAGING_DIR=""
 STAGED_APP_PATH=""
+APP_INFO_PLIST_SRC="$PROJECT_ROOT/PingWarden/Info.plist"
+
+# Cross-check the version argument against the app's Info.plist so a DMG can
+# never be produced whose Sparkle version metadata mismatches its contents.
+PLIST_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_INFO_PLIST_SRC" 2>/dev/null || true)
+if [ -n "$PLIST_VERSION" ] && [ "$PLIST_VERSION" != "$VERSION" ]; then
+    echo "Error: version mismatch — argument is $VERSION but Info.plist says $PLIST_VERSION." >&2
+    exit 1
+fi
 
 # Colors
 GREEN='\033[0;32m'
@@ -208,9 +223,14 @@ fi
 # Step 2: Verify code signing
 echo ""
 echo "Verifying code signature..."
-if ! codesign --verify --deep --strict --verbose=2 "$STAGED_APP_PATH" 2>&1 | grep -q "satisfies"; then
+# Buffer the output before grep (same SIGPIPE/pipefail hazard documented for
+# CODESIGN_INFO above: `grep -q` exits at first match while codesign is still
+# writing, turning a *successful* verify into exit 141).
+DEEP_VERIFY_OUTPUT="$(codesign --verify --deep --strict --verbose=2 "$STAGED_APP_PATH" 2>&1 || true)"
+if ! printf '%s\n' "$DEEP_VERIFY_OUTPUT" | grep -q "satisfies"; then
     echo -e "${RED}Error: App is not properly code signed${NC}"
     echo "Make sure you built with Developer ID Application certificate"
+    printf '%s\n' "$DEEP_VERIFY_OUTPUT"
     exit 1
 fi
 
@@ -241,9 +261,12 @@ echo "Submitting to Apple for notarization..."
 echo "This may take 1-10 minutes..."
 echo ""
 
+# `|| true` so a notarytool failure (auth expiry, network) doesn't trip
+# set -e on the assignment itself — that used to kill the script before the
+# diagnostic output below could ever be printed.
 SUBMIT_OUTPUT=$(xcrun notarytool submit "$ZIP_NAME" \
     "${NOTARYTOOL_ARGS[@]}" \
-    --wait 2>&1)
+    --wait 2>&1) || true
 
 echo "$SUBMIT_OUTPUT"
 
@@ -267,9 +290,15 @@ echo -e "${GREEN}✓${NC} Ticket stapled successfully"
 # Step 6: Create notarized DMG
 echo ""
 echo "Creating notarized DMG..."
+if [ ! -f "$CREATE_DMG_SCRIPT" ]; then
+    # Previously this block was silently skipped, printing "Notarization
+    # Complete!" and exiting 0 with no DMG produced.
+    echo -e "${RED}Error: create-dmg.sh not found at $CREATE_DMG_SCRIPT${NC}"
+    exit 1
+fi
 if [ -f "$CREATE_DMG_SCRIPT" ]; then
     "$CREATE_DMG_SCRIPT" "$VERSION" "$STAGED_APP_PATH"
-    
+
     if [ -f "$DMG_NAME" ]; then
         echo ""
         echo "Signing DMG with Developer ID..."
@@ -281,7 +310,7 @@ if [ -f "$CREATE_DMG_SCRIPT" ]; then
         echo "Submitting DMG to Apple for notarization..."
         DMG_SUBMIT_OUTPUT=$(xcrun notarytool submit "$DMG_NAME" \
             "${NOTARYTOOL_ARGS[@]}" \
-            --wait 2>&1)
+            --wait 2>&1) || true
         echo "$DMG_SUBMIT_OUTPUT"
         
         if ! echo "$DMG_SUBMIT_OUTPUT" | grep -q "status: Accepted"; then
@@ -294,6 +323,9 @@ if [ -f "$CREATE_DMG_SCRIPT" ]; then
         echo "Stapling DMG..."
         xcrun stapler staple "$DMG_NAME"
         echo -e "${GREEN}✓${NC} DMG stapled"
+    else
+        echo -e "${RED}Error: create-dmg.sh ran but $DMG_NAME was not produced${NC}"
+        exit 1
     fi
 fi
 

--- a/PingWarden/PingWarden/release.sh
+++ b/PingWarden/PingWarden/release.sh
@@ -242,7 +242,10 @@ echo ""
 
 # Step 4: Get file size and date
 DMG_SIZE=$(stat -f%z "$DMG_PATH")
-DMG_DATE=$(date -u +"%a, %d %b %Y %H:%M:%S %Z")
+# LC_ALL=C keeps day/month names English (RFC 822 requires them; a localized
+# LC_TIME would emit names Sparkle's date parser rejects), and +0000 is used
+# because "UTC" is not a valid RFC 822 zone token.
+DMG_DATE=$(LC_ALL=C date -u +"%a, %d %b %Y %H:%M:%S +0000")
 
 echo -e "${GREEN}Step 3: Preparing release metadata...${NC}"
 echo "  Version: $VERSION"
@@ -369,21 +372,35 @@ if ! command -v gh &> /dev/null; then
     echo "5. Copy notes from $RELEASE_NOTES"
     echo ""
 else
-    # Create release with gh CLI
-    if [ -f "$RELEASE_NOTES_PATH" ]; then
-        gh release create "v$VERSION" \
-            "$DMG_PATH" \
-            --title "Ping Warden v$VERSION" \
-            --target "$CURRENT_SHA" \
-            --notes-file "$RELEASE_NOTES_PATH"
-    else
-        gh release create "v$VERSION" \
-            "$DMG_PATH" \
-            --title "Ping Warden v$VERSION" \
-            --target "$CURRENT_SHA" \
-            --notes "See CHANGELOG for details"
+    # Betas (and any semver pre-release tag) must be marked --prerelease or
+    # GitHub promotes them to "latest release", pointing the README badge and
+    # releases/latest at a beta DMG for stable users.
+    GH_RELEASE_FLAGS=()
+    if [ "${BETA_CHANNEL:-0}" = "1" ] || [[ "$VERSION" == *-* ]]; then
+        GH_RELEASE_FLAGS+=(--prerelease)
+        echo "  ✓ marking GitHub release as pre-release"
     fi
-    
+
+    # Prefer just this version's section from RELEASE_NOTES.md; the file
+    # passed as $2 is the full multi-version history, and using it verbatim
+    # put every release's notes on every release page.
+    GH_NOTES_ARGS=()
+    if VERSION_NOTES=$("$RENDER_SCRIPT" "$VERSION" --markdown 2>/dev/null) && [ -n "$VERSION_NOTES" ]; then
+        GH_NOTES_ARGS=(--notes "$VERSION_NOTES")
+    elif [ -f "$RELEASE_NOTES_PATH" ]; then
+        echo -e "${YELLOW}  ⚠ could not extract v$VERSION section; using $RELEASE_NOTES_PATH verbatim${NC}"
+        GH_NOTES_ARGS=(--notes-file "$RELEASE_NOTES_PATH")
+    else
+        GH_NOTES_ARGS=(--notes "See CHANGELOG for details")
+    fi
+
+    gh release create "v$VERSION" \
+        "$DMG_PATH" \
+        --title "Ping Warden v$VERSION" \
+        --target "$CURRENT_SHA" \
+        "${GH_RELEASE_FLAGS[@]}" \
+        "${GH_NOTES_ARGS[@]}"
+
     echo -e "${GREEN}✓ GitHub release created${NC}"
 fi
 
@@ -432,16 +449,21 @@ else
     # the script before gh-pages gets updated. The subshell + set +e localizes
     # the relaxed error handling, and the trailing summary makes any failures
     # visible rather than silently passing.
+    # NOTE: the subshell must be run inside an `if !` so its non-zero exit is
+    # exempt from the outer `set -e` — a bare `( ... ); SENTRY_FAILURES=$?`
+    # aborts the whole script on failure before gh-pages is pushed, which is
+    # exactly the failure mode this block exists to prevent.
     SENTRY_FAILURES=0
-    (
+    if ! (
         set +e
         sentry-cli debug-files upload "$XCARCHIVE_DSYMS" || exit 1
         sentry-cli releases new "$SENTRY_RELEASE" || exit 2
         sentry-cli releases set-commits "$SENTRY_RELEASE" --auto || true  # needs repo integration; non-fatal
         sentry-cli releases finalize "$SENTRY_RELEASE" || exit 4
         exit 0
-    )
-    SENTRY_FAILURES=$?
+    ); then
+        SENTRY_FAILURES=$?
+    fi
 
     unset SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT SENTRY_LOG_LEVEL
     if [ "$SENTRY_FAILURES" = "0" ]; then
@@ -493,10 +515,19 @@ else
 
     restore_branch() {
         local rc=$?
-        # Best-effort: return to the original branch and pop the stash.
-        git -C "$REPO_ROOT" checkout --quiet "$ORIGINAL_BRANCH" 2>/dev/null || true
+        # Best-effort, but LOUD on failure: silently continuing here can pop
+        # the stash onto the wrong branch or strand it entirely.
+        if ! git -C "$REPO_ROOT" checkout --quiet "$ORIGINAL_BRANCH" 2>/dev/null; then
+            echo -e "${RED}⚠ Could not return to branch '$ORIGINAL_BRANCH' — repo left on $(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD).${NC}" >&2
+            if [ "$STASHED" = "1" ]; then
+                echo -e "${RED}⚠ Your pre-release changes are stashed (git stash list) — NOT popping onto the wrong branch.${NC}" >&2
+            fi
+            return $rc
+        fi
         if [ "$STASHED" = "1" ]; then
-            git -C "$REPO_ROOT" stash pop --quiet 2>/dev/null || true
+            if ! git -C "$REPO_ROOT" stash pop --quiet 2>/dev/null; then
+                echo -e "${RED}⚠ git stash pop failed (conflict?). Your changes remain in the stash — resolve with 'git stash pop' manually.${NC}" >&2
+            fi
         fi
         return $rc
     }
@@ -509,7 +540,10 @@ else
     cp "$APPCAST_SNAPSHOT" "$REPO_ROOT/$APPCAST_BASENAME"
     rm -f "$APPCAST_SNAPSHOT"
 
-    if git -C "$REPO_ROOT" diff --quiet -- "$APPCAST_BASENAME"; then
+    # status --porcelain (not diff --quiet): a first-ever beta appcast is an
+    # UNTRACKED file on gh-pages, which `git diff --quiet` reports as
+    # unchanged — silently skipping the push and 404ing the beta feed.
+    if [ -z "$(git -C "$REPO_ROOT" status --porcelain -- "$APPCAST_BASENAME")" ]; then
         echo -e "${YELLOW}gh-pages $APPCAST_BASENAME already matches v$VERSION; nothing to push.${NC}"
     else
         git -C "$REPO_ROOT" add "$APPCAST_BASENAME"

--- a/PingWarden/PingWardenHelper/Info.plist
+++ b/PingWarden/PingWardenHelper/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.3</string>
+	<string>2.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.4.3</string>
+	<string>2.5.0</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>13.0</string>
 	<key>NSHumanReadableCopyright</key>

--- a/PingWarden/PingWardenHelper/PingWardenMonitor.h
+++ b/PingWarden/PingWardenHelper/PingWardenMonitor.h
@@ -32,6 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// Should be called before the helper exits.
 - (void)invalidate;
 
+/// Bring awdl0 back UP with a direct ioctl on the calling thread.
+/// Exit-path safety net: works even if the poll thread is dead or the
+/// control pipe is gone. Call only after `invalidate`.
+- (void)restoreInterfaceUpDirectly;
+
 /// Get the total number of AWDL interventions (how many times we blocked AWDL from coming up)
 /// This counter persists for the lifetime of the helper process
 - (NSInteger)getInterventionCount;

--- a/PingWarden/PingWardenHelper/PingWardenMonitor.m
+++ b/PingWarden/PingWardenHelper/PingWardenMonitor.m
@@ -382,6 +382,14 @@ _Static_assert(sizeof("awdl0") <= IFNAMSIZ, "TARGETIFNAM must fit in IFNAMSIZ");
 }
 
 - (BOOL)setAwdlEnabled:(BOOL)enabled {
+    // If the poll thread has died (poll() error, quit), a pipe write would
+    // still "succeed" into a readerless buffer while nothing enforces the
+    // state — the app would believe AWDL is blocked when it isn't. Fail
+    // loudly instead so the client can surface the problem.
+    if (!atomic_load(&_threadRunning)) {
+        os_log_error(LOG, "Cannot set AWDL state to %d: monitor thread is not running", enabled);
+        return NO;
+    }
     const char *msg = enabled ? "U" : "D";
     if (![self writeMessageToPipe:msg]) {
         os_log_error(LOG, "Failed to send %s message to pipe", enabled ? "enable" : "disable");
@@ -389,6 +397,38 @@ _Static_assert(sizeof("awdl0") <= IFNAMSIZ, "TARGETIFNAM must fit in IFNAMSIZ");
     }
     atomic_store(&_awdlEnabledAtomic, enabled);
     return YES;
+}
+
+- (void)restoreInterfaceUpDirectly {
+    // Last-resort restore used on exit paths. Performs the ioctl directly on
+    // the calling thread with a transient socket, so it works even when the
+    // poll thread is dead or the control pipe is gone. Must only run after
+    // `invalidate` (the poll thread no longer touches interface flags).
+    atomic_store(&_awdlEnabledAtomic, true);
+
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        os_log_error(LOG, "restoreInterfaceUpDirectly: socket failed: %d (%s)", errno, strerror(errno));
+        return;
+    }
+
+    struct ifreq ifr = {0};
+    strlcpy(ifr.ifr_name, TARGETIFNAM, IFNAMSIZ);
+    if (ioctl(fd, SIOCGIFFLAGS, &ifr) < 0) {
+        os_log_error(LOG, "restoreInterfaceUpDirectly: SIOCGIFFLAGS failed: %d (%s)", errno, strerror(errno));
+        close(fd);
+        return;
+    }
+
+    if (!(ifr.ifr_flags & IFF_UP)) {
+        ifr.ifr_flags |= IFF_UP;
+        if (ioctl(fd, SIOCSIFFLAGS, &ifr) < 0) {
+            os_log_error(LOG, "restoreInterfaceUpDirectly: SIOCSIFFLAGS failed: %d (%s)", errno, strerror(errno));
+        } else {
+            os_log(LOG, "Restored awdl0 UP via direct ioctl before exit");
+        }
+    }
+    close(fd);
 }
 
 - (void)invalidate {
@@ -409,6 +449,12 @@ _Static_assert(sizeof("awdl0") <= IFNAMSIZ, "TARGETIFNAM must fit in IFNAMSIZ");
             os_log_error(LOG, "Timeout waiting for pollIoctl thread to exit");
             // Mark thread as not running to prevent further issues (atomic write)
             atomic_store(&_threadRunning, false);
+            // Deliberately leak the fds: the poller may still be blocked in
+            // poll()/read() on them, and closing here would let the process
+            // recycle the descriptor numbers underneath a live reader. Both
+            // callers exit the process moments later, so the leak is bounded.
+            os_log(LOG, "PingWardenMonitor invalidated (fds leaked pending process exit)");
+            return;
         }
     }
 

--- a/PingWarden/PingWardenHelper/main.m
+++ b/PingWarden/PingWardenHelper/main.m
@@ -20,7 +20,7 @@
 #define LOG OS_LOG_DEFAULT
 // Fallback only — the live version is read from the embedded Info.plist by
 // helperVersionString(). Kept current so the fallback is never stale.
-#define HELPER_VERSION @"2.4.0"
+#define HELPER_VERSION @"2.5.0"
 
 // Team ID for code signing validation
 #define TEAM_ID @"PV3W52NDZ3"
@@ -30,9 +30,22 @@
 // tearing down monitoring and re-enabling AWDL mid-session.
 #define EXIT_GRACE_PERIOD_SECONDS 60.0
 
+@class PingWardenService;
+
 static NSInteger activeConnectionCount = 0;
 static dispatch_queue_t connectionCountQueue;
+// Set on connectionCountQueue once the exit decision is final; connections
+// arriving after this point are rejected so the count check cannot race exit.
+static BOOL isExiting = NO;
+// Mutated only on the main queue (scheduleExit and the main-queue hop in
+// shouldAcceptNewConnection) so cancel/recreate cannot race across threads.
 static dispatch_source_t exitTimer = nil;
+// Keep the service and listener alive for the whole process lifetime.
+// main() never returns from dispatch_main(), and ARC is allowed to release
+// locals after their last use — the listener's weak delegate would then go
+// nil and the daemon would silently stop accepting connections.
+static PingWardenService *gService = nil;
+static NSXPCListener *gListener = nil;
 
 #pragma mark - Version
 
@@ -174,23 +187,33 @@ static BOOL isProperlyCodeSigned(void) {
             exit(0);
         }
 
-        // Double-check no connections were established during grace period
-        // Use dispatch_async to avoid potential deadlock with main queue
+        // Make the exit decision atomically with the connection count: the
+        // count check and the `isExiting` flip happen in one block on
+        // connectionCountQueue, and shouldAcceptNewConnection increments on
+        // the same queue synchronously — so a connection is either counted
+        // here (exit aborted) or rejected by the flag. No TOCTOU window.
         dispatch_async(connectionCountQueue, ^{
-            NSInteger currentCount = activeConnectionCount;
+            if (activeConnectionCount > 0) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    os_log(LOG, "Exit cancelled - active connection(s) present");
+                });
+                return;
+            }
+            isExiting = YES;
 
             // Return to main queue for the actual exit logic
             dispatch_async(dispatch_get_main_queue(), ^{
-                if (currentCount > 0) {
-                    os_log(LOG, "Exit cancelled - %ld active connection(s)", (long)currentCount);
-                    return;
-                }
-
                 os_log(LOG, "Grace period expired, restoring AWDL and exiting");
 
-                // Restore AWDL to enabled state before exiting
-                [strongSelf.monitor setAwdlEnabled:YES];
+                // Restore AWDL to enabled state before exiting. The pipe
+                // write is best-effort; the direct ioctl below guarantees
+                // the interface is not left down even if the poll thread
+                // is already dead or the pipe write failed.
+                if (![strongSelf.monitor setAwdlEnabled:YES]) {
+                    os_log_error(LOG, "setAwdlEnabled:YES failed on exit path - falling back to direct restore");
+                }
                 [strongSelf.monitor invalidate];
+                [strongSelf.monitor restoreInterfaceUpDirectly];
 
                 // Give a moment for cleanup, then exit
                 dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)),
@@ -226,13 +249,27 @@ static BOOL isProperlyCodeSigned(void) {
         return NO;
     }
 
-    // Cancel pending exit if a new connection arrives
-    [self cancelExitTimer];
-
-    // Use dispatch_async to avoid potential deadlock from XPC callback context
-    dispatch_async(connectionCountQueue, ^{
+    // Count the connection synchronously so the exit timer's atomic
+    // count-check/isExiting decision on the same serial queue can never
+    // miss it; reject outright if the exit decision was already made.
+    __block BOOL acceptedForCounting = NO;
+    dispatch_sync(connectionCountQueue, ^{
+        if (isExiting) {
+            return;
+        }
         activeConnectionCount++;
+        acceptedForCounting = YES;
         os_log_debug(LOG, "Active connections: %ld", (long)activeConnectionCount);
+    });
+    if (!acceptedForCounting) {
+        os_log(LOG, "Rejecting XPC connection: helper is exiting");
+        return NO;
+    }
+
+    // Cancel pending exit if a new connection arrives. exitTimer is confined
+    // to the main queue; this delegate runs on the listener's queue.
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self cancelExitTimer];
     });
 
     __weak typeof(self) weakSelf = self;
@@ -290,8 +327,13 @@ static dispatch_source_t setupSignalHandler(PingWardenService *service) {
         dispatch_source_set_event_handler(signalSource, ^{
             os_log(LOG, "Received SIGTERM via dispatch, performing graceful shutdown");
             if (service && service.monitor) {
-                [service.monitor setAwdlEnabled:YES];
+                if (![service.monitor setAwdlEnabled:YES]) {
+                    os_log_error(LOG, "setAwdlEnabled:YES failed during SIGTERM - falling back to direct restore");
+                }
                 [service.monitor invalidate];
+                // Guarantee awdl0 is not left down even if the pipe write
+                // failed or the poll thread was already dead.
+                [service.monitor restoreInterfaceUpDirectly];
             }
             os_log(LOG, "PingWardenHelper exiting due to SIGTERM");
             // Give a moment for cleanup
@@ -350,8 +392,23 @@ int main(int argc, const char * argv[]) {
                 listener.connectionCodeSigningRequirement = requirement;
             }
         } else {
-            os_log(LOG, "WARNING: Running without code signing requirement - relying on UID-based validation only");
+#if DEBUG
+            os_log(LOG, "WARNING: Debug build without code signing requirement - relying on UID-based validation only");
+#else
+            // Fail closed: a release build of a root daemon whose own
+            // signature does not validate is either tampered with or a
+            // broken install. Downgrading to UID-only validation would let
+            // any GUI-user process drive a root-owned network control.
+            os_log_error(LOG, "Refusing to serve: code signature validation failed on a release build");
+            return EXIT_FAILURE;
+#endif
         }
+
+        // Anchor the service and listener in immortal globals (see the
+        // declarations above for why ARC would otherwise be free to release
+        // them once dispatch_main() is entered).
+        gService = service;
+        gListener = listener;
 
         listener.delegate = service;
         [listener activate];

--- a/PingWarden/PingWardenWidget/Info.plist
+++ b/PingWarden/PingWardenWidget/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.3</string>
+	<string>2.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.4.3</string>
+	<string>2.5.0</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/PingWarden/PingWardenWidget/PingWardenPreferences.swift
+++ b/PingWarden/PingWardenWidget/PingWardenPreferences.swift
@@ -17,7 +17,7 @@ private let log = Logger(subsystem: "com.amesvt.pingwarden", category: "WidgetPr
 /// Note: This file should be kept in sync with PingWarden/PingWardenPreferences.swift
 /// The widget only uses isMonitoringEnabled and lastKnownState, but all properties
 /// are included for consistency and to ensure key names match.
-class PingWardenPreferences {
+final class PingWardenPreferences: @unchecked Sendable {
     static let shared = PingWardenPreferences()
 
     private let appGroupID = "group.com.amesvt.pingwarden"
@@ -29,18 +29,29 @@ class PingWardenPreferences {
     private let showDockIconKey = "ShowDockIcon"
     private let showMenuDropdownMetricsKey = "ShowMenuDropdownMetrics"
 
-    private lazy var defaults: UserDefaults? = {
-        guard let suite = UserDefaults(suiteName: appGroupID) else {
+    // Assigned once in init (a `lazy var` is not thread-safe and the async
+    // intent perform() can race control rendering on first access).
+    private let defaults: UserDefaults?
+
+    /// True when the shared App Group suite is in use. When false, the widget
+    /// and the main app are reading *different* defaults domains — writes
+    /// from here would appear to succeed while the app never sees them, so
+    /// intent handlers must surface an error instead of proceeding.
+    let usesAppGroupSuite: Bool
+
+    private init() {
+        if let suite = UserDefaults(suiteName: appGroupID) {
+            log.debug("Successfully connected to App Group suite")
+            defaults = suite
+            usesAppGroupSuite = true
+        } else {
             // Fallback to standard defaults if app group fails
             // This matches the main app's behavior for consistency
-            log.error("Failed to create App Group suite '\(self.appGroupID)', using standard defaults")
-            return UserDefaults.standard
+            log.error("Failed to create App Group suite, using standard defaults")
+            defaults = UserDefaults.standard
+            usesAppGroupSuite = false
         }
-        log.debug("Successfully connected to App Group suite")
-        return suite
-    }()
-
-    private init() {}
+    }
 
     /// Whether continuous AWDL monitoring is enabled
     var isMonitoringEnabled: Bool {

--- a/PingWarden/PingWardenWidget/PingWardenToggleIntent.swift
+++ b/PingWarden/PingWardenWidget/PingWardenToggleIntent.swift
@@ -61,8 +61,24 @@ struct ToggleAWDLMonitoringIntent: AppIntent {
 }
 
 private enum PingProtectionIntentHandler {
+    private enum LaunchOutcome {
+        case alreadyRunning
+        case launched
+        case failed
+    }
+
     static func apply(desiredState: Bool) async throws {
         let preferences = PingWardenPreferences.shared
+
+        // Without the shared App Group suite the widget and the app read
+        // different defaults domains: the write below would verify fine here
+        // while the app never sees it. Fail visibly instead of toggling a
+        // control that does nothing.
+        guard preferences.usesAppGroupSuite else {
+            log.error("App Group suite unavailable - refusing to toggle into a split-brain state")
+            throw AWDLError.toggleFailed
+        }
+
         let previousIntentState = preferences.isMonitoringEnabled
         let previousEffectiveState = preferences.effectiveMonitoringEnabled
         log.info("Setting monitoring intent from \(previousIntentState) to \(desiredState)")
@@ -79,27 +95,38 @@ private enum PingProtectionIntentHandler {
         // Enabling always needs the main app to apply helper state. Disabling
         // also needs the app if the last effective state says protection is active.
         let launchRequired = desiredState || previousEffectiveState != desiredState
-        let didLaunch = launchRequired ? await launchMainAppIfNeeded() : false
+        let launchOutcome = launchRequired ? await launchMainAppIfNeeded() : LaunchOutcome.alreadyRunning
 
-        if didLaunch {
+        switch launchOutcome {
+        case .alreadyRunning:
+            break
+        case .launched:
             // Give the app a brief moment to finish launch and process intent signal.
+            // (The app also reconciles intent vs. runtime state at startup, so
+            // this repost is belt-and-braces rather than load-bearing.)
             try? await Task.sleep(nanoseconds: 700_000_000)
             postMonitoringIntentNotification()
             ControlCenter.shared.reloadControls(ofKind: PingWardenControlKind.pingProtection)
+        case .failed:
+            // Roll back the intent so the toggle doesn't show a state that
+            // nothing will ever apply, then surface the failure.
+            preferences.isMonitoringEnabled = previousIntentState
+            ControlCenter.shared.reloadControls(ofKind: PingWardenControlKind.pingProtection)
+            log.error("Main app could not be launched - rolled back monitoring intent")
+            throw AWDLError.appLaunchFailed
         }
 
         log.info("Successfully set monitoring intent to \(desiredState)")
     }
 
     /// Launch the main app if it's not already running
-    @discardableResult
-    private static func launchMainAppIfNeeded() async -> Bool {
+    private static func launchMainAppIfNeeded() async -> LaunchOutcome {
         let bundleIdentifier = "com.amesvt.pingwarden"
 
         // Check if app is already running
         guard !isMainAppRunning(bundleIdentifier: bundleIdentifier) else {
             log.debug("Main app already running")
-            return false
+            return .alreadyRunning
         }
 
         log.info("Main app not running, attempting to launch...")
@@ -113,14 +140,14 @@ private enum PingProtectionIntentHandler {
             do {
                 _ = try await NSWorkspace.shared.openApplication(at: appURL, configuration: configuration)
                 log.info("Successfully launched main app")
-                return true
+                return .launched
             } catch {
                 log.error("Failed to launch main app: \(error.localizedDescription)")
             }
         } else {
             log.warning("Could not find main app URL for bundle identifier: \(bundleIdentifier)")
         }
-        return false
+        return .failed
     }
 
     private static func isMainAppRunning(bundleIdentifier: String) -> Bool {

--- a/PingWarden/PingWardenWidget/PingWardenWidget.swift
+++ b/PingWarden/PingWardenWidget/PingWardenWidget.swift
@@ -24,7 +24,12 @@ struct PingWardenWidget: ControlWidget {
 
     var body: some ControlWidgetConfiguration {
         StaticControlConfiguration(kind: Self.kind) {
-            let isOn = PingWardenPreferences.shared.effectiveMonitoringEnabled || PingWardenPreferences.shared.isMonitoringEnabled
+            // Display user *intent*, which is exactly what the toggle intent
+            // sets. Mixing in the effective runtime state made the toggle
+            // snap back to On after a disable (effective stayed true until
+            // the app processed the change) and made
+            // ToggleAWDLMonitoringIntent flip a different state than shown.
+            let isOn = PingWardenPreferences.shared.isMonitoringEnabled
             ControlWidgetToggle(isOn: isOn, action: SetPingProtectionIntent()) {
                 Label(
                     isOn ? "Protection On" : "Protection Off",

--- a/PingWarden/create-dmg.sh
+++ b/PingWarden/create-dmg.sh
@@ -14,7 +14,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Configuration
 APP_NAME="Ping Warden"
-VERSION="${1:-2.2.1}"
+VERSION="${1:-}"
+if [ -z "$VERSION" ]; then
+    echo "Error: version argument is required (a stale default here once produced" >&2
+    echo "DMGs whose filename didn't match their contents)." >&2
+    echo "Usage: ./create-dmg.sh <version> [app-path]" >&2
+    exit 1
+fi
 DMG_NAME="PingWarden-${VERSION}"
 BUILD_DIR="$SCRIPT_DIR/build"
 DMG_PATH="$SCRIPT_DIR/${DMG_NAME}.dmg"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,45 @@
+# Ping Warden 2.5.0
+
+[Support Ping Warden on Buy Me a Coffee](https://buymeacoffee.com/oliverames)
+
+Ping Warden 2.5.0 is a reliability-focused release: a full audit of the helper daemon, XPC layer, widget sync, monitoring pipeline, and release tooling, with dozens of fixes.
+
+## Changelog
+
+### Protection Reliability
+- **Protection now survives quit + relaunch**: Quitting the app no longer silently turns the Ping Protection preference off. If protection was on when you quit, it turns back on at the next launch.
+- **Helper can never strand your Wi-Fi radio off**: Every helper exit path (grace-period shutdown, system termination) now guarantees the wireless interface is restored via a direct fallback, even if the helper's internal monitoring thread had died.
+- **Honest failure reporting from the helper**: If the helper's kernel-event thread stops, protection commands now fail visibly instead of pretending to succeed while nothing was being enforced.
+- **XPC reconnect fixed**: The reconnect retry counter is now only reset after the helper actually responds, closing an infinite silent reconnect loop when the helper was unregistered mid-session. Abandoned connections are also properly invalidated (fixing a slow resource leak), and a reconnect can no longer overwrite a stop you issued while it was in flight.
+- **Helper setup can no longer wedge**: An interrupted registration flow used to permanently block future "Enable Ping Protection" attempts until app restart; registration polling now always resolves.
+- **Race-free helper shutdown**: The helper's exit decision is now atomic with connection tracking, so an app reconnect can never be dropped mid-shutdown (which previously caused a brief AWDL flap — the exact latency spike the app prevents).
+- **Hardened privileged daemon**: Release builds of the root helper now refuse to run if their code signature fails validation instead of downgrading to weaker checks.
+
+### Game Mode & Quick Pause
+- **Game detection now recognizes most games**: Apps declaring a game *subcategory* (action, RPG, strategy, …) in their Info.plist were never detected as games; now they are.
+- **Pause and Game Mode no longer fight each other**: Pausing during a game session is honored when the game ends; a pause that expires mid-game restores your protection preference instead of leaving protection off permanently.
+- **Pause timer reliability**: The 10-minute auto-resume now fires even while a menu or dialog is open, and the menu's Pause/Resume items enable/disable correctly.
+
+### Control Center Widget
+- **Widget state stays in sync**: The app now tells Control Center to refresh the toggle whenever protection changes from the menu bar, Settings, or Game Mode — the widget no longer displays stale state indefinitely.
+- **Toggling off no longer snaps back to on**: The widget now displays and toggles the same state, fixing both the visual snap-back after disabling and a Shortcuts toggle that could never turn auto-enabled protection off.
+- **Launch failures surface**: If the main app can't be launched to apply a widget toggle, the toggle now reverts and reports an error instead of showing protection as on while nothing happened.
+- **Lockout prevention hardened**: Hiding the dock icon while in Control Center mode (menu bar hidden) is now blocked at all times, not just at the moment Control Center mode is enabled.
+
+### Ping Monitoring & Dashboard
+- **Accurate latency numbers**: Measured ping now excludes DNS resolution time and failed connection attempts — dual-stack hostnames no longer report ~1000 ms "successful" pings that poisoned averages, jitter, spike events, and Auto-Select rankings.
+- **Unresponsive DNS can't freeze monitoring**: Hostname resolution now runs with a bounded deadline, so a hung resolver no longer stalls the entire ping pipeline and dashboard.
+- **Saved server selection survives relaunch**: A selected GeForce NOW zone or local-gateway target is now restored once its source loads, instead of silently falling back to Cloudflare DNS forever.
+- **Transient GFN outages keep your zones**: A failed GeForce NOW server-list refresh no longer wipes previously discovered zones (which reset your selection and erased chart history).
+- **Dashboard chart performance**: Chart data is now memoized and downsampled (spikes always preserved), cutting per-second CPU dramatically on long timeframes — exactly during the gaming sessions the app protects.
+- **Smaller fixes**: duplicate server entries are deduplicated everywhere; protection events that occur while the dashboard is closed no longer appear as one mistimed event; auto-select probes no longer starve the app's async runtime; settings window size/position is remembered again; diagnostics export falls back to a temp folder if Desktop access is denied; the quarantine-fix command now uses the app's real location; automatic update checks start correctly after first-run setup.
+
+### Release Tooling & CI
+- **Cross-platform test suite**: The core logic package now compiles and tests on Linux; CI gained an `ubuntu-latest` `swift test` job (plus 8 new tests) and shellcheck coverage for all scripts.
+- **Release script fixes**: Sentry upload failures can no longer abort a release before the appcast is published; first-ever beta appcasts publish correctly; beta releases are marked as GitHub pre-releases; GitHub release pages now show only that version's notes; notarization failures print their diagnostics instead of dying silently; version arguments are validated against Info.plist.
+
+---
+
 # Ping Warden 2.4.3
 
 [Support Ping Warden on Buy Me a Coffee](https://buymeacoffee.com/oliverames)

--- a/Tests/PingWardenCoreTests/CoreLogicTests.swift
+++ b/Tests/PingWardenCoreTests/CoreLogicTests.swift
@@ -6,10 +6,32 @@
 //  PingWarden/PingWarden/Core/. Run with `swift test`.
 //
 
-import Darwin
 import Foundation
 import XCTest
 @testable import PingWardenCore
+
+// POSIX socket calls are referenced through module-qualified constants
+// because inside an XCTestCase subclass `bind`, `listen`, and `close`
+// shadow the global C functions with NSObject's KVO `bind(_:to:withKeyPath:options:)`
+// and friends. The indirection also keeps the suite compiling on Linux,
+// where the symbols live in Glibc instead of Darwin.
+#if canImport(Darwin)
+import Darwin
+private let sysSocket: (Int32, Int32, Int32) -> Int32 = Darwin.socket
+private let sysBind: (Int32, UnsafePointer<sockaddr>?, socklen_t) -> Int32 = Darwin.bind
+private let sysListen: (Int32, Int32) -> Int32 = Darwin.listen
+private let sysClose: (Int32) -> Int32 = Darwin.close
+private let sysGetsockname: (Int32, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> Int32 = Darwin.getsockname
+private let sysSockStream = SOCK_STREAM
+#elseif canImport(Glibc)
+import Glibc
+private let sysSocket: (Int32, Int32, Int32) -> Int32 = Glibc.socket
+private let sysBind: (Int32, UnsafePointer<sockaddr>?, socklen_t) -> Int32 = Glibc.bind
+private let sysListen: (Int32, Int32) -> Int32 = Glibc.listen
+private let sysClose: (Int32) -> Int32 = Glibc.close
+private let sysGetsockname: (Int32, UnsafeMutablePointer<sockaddr>?, UnsafeMutablePointer<socklen_t>?) -> Int32 = Glibc.getsockname
+private let sysSockStream = Int32(SOCK_STREAM.rawValue)
+#endif
 
 final class PingStatisticsTests: XCTestCase {
     func testEmptySamplesReportZeroAndPoorQuality() {
@@ -56,6 +78,48 @@ final class PingStatisticsTests: XCTestCase {
         let result = PingStatistics.calculate(from: samples)
         XCTAssertEqual(result.quality, .good)
     }
+
+    func testFairQualityBand() {
+        let now = Date()
+        let samples = (0..<5).map { index in
+            PingSample(latencyMs: 75, success: true, timestamp: now.addingTimeInterval(Double(index)))
+        }
+        let result = PingStatistics.calculate(from: samples)
+        XCTAssertEqual(result.quality, .fair)
+    }
+
+    func testMinimumAndMaximumPing() {
+        let now = Date()
+        let samples = [
+            PingSample(latencyMs: 30, success: true, timestamp: now),
+            PingSample(latencyMs: 12, success: true, timestamp: now.addingTimeInterval(1)),
+            PingSample(latencyMs: 44, success: true, timestamp: now.addingTimeInterval(2))
+        ]
+        let result = PingStatistics.calculate(from: samples)
+        XCTAssertEqual(result.minimumPing, 12, accuracy: 0.0001)
+        XCTAssertEqual(result.maximumPing, 44, accuracy: 0.0001)
+    }
+
+    /// Non-empty input where every probe failed: 100% loss, zeroed latency
+    /// stats, poor quality — and no divide-by-zero on the empty success set.
+    func testAllFailuresReportTotalLossAndPoorQuality() {
+        let now = Date()
+        let samples = (0..<3).map { index in
+            PingSample(latencyMs: 1000, success: false, timestamp: now.addingTimeInterval(Double(index)))
+        }
+        let result = PingStatistics.calculate(from: samples)
+        XCTAssertEqual(result.packetLoss, 100, accuracy: 0.0001)
+        XCTAssertEqual(result.currentPing, 0)
+        XCTAssertEqual(result.averagePing, 0)
+        XCTAssertEqual(result.quality, .poor)
+    }
+
+    func testSingleSampleHasZeroJitter() {
+        let result = PingStatistics.calculate(from: [
+            PingSample(latencyMs: 25, success: true, timestamp: Date())
+        ])
+        XCTAssertEqual(result.jitter, 0)
+    }
 }
 
 final class XPCReconnectPolicyTests: XCTestCase {
@@ -67,6 +131,23 @@ final class XPCReconnectPolicyTests: XCTestCase {
 
     func testNonPositiveAttemptReturnsZero() {
         XCTAssertEqual(XPCReconnectPolicy.delayForAttempt(0), 0.0, accuracy: 0.0001)
+    }
+
+    /// The backoff must be capped: uncapped, attempt 31 is ~12 days and
+    /// attempt 1100 overflows pow() to +inf, silently ending retries.
+    func testLargeAttemptsAreCappedAndFinite() {
+        XCTAssertEqual(XPCReconnectPolicy.delayForAttempt(31), XPCReconnectPolicy.maxDelaySeconds)
+        XCTAssertEqual(XPCReconnectPolicy.delayForAttempt(1100), XPCReconnectPolicy.maxDelaySeconds)
+        XCTAssertTrue(XPCReconnectPolicy.delayForAttempt(Int.max).isFinite)
+    }
+
+    func testDelaysAreMonotonicallyNonDecreasing() {
+        var previous: TimeInterval = 0
+        for attempt in 1...40 {
+            let delay = XPCReconnectPolicy.delayForAttempt(attempt)
+            XCTAssertGreaterThanOrEqual(delay, previous)
+            previous = delay
+        }
     }
 }
 
@@ -100,11 +181,7 @@ final class TCPProbeTests: XCTestCase {
     }
 
     private static func startLoopbackListener() -> UInt16? {
-        // POSIX socket calls are qualified with `Darwin.` because inside an
-        // XCTestCase subclass `bind`, `listen`, and `close` shadow the global
-        // C functions with NSObject's KVO `bind(_:to:withKeyPath:options:)`
-        // and friends.
-        let listenerFD = Darwin.socket(AF_INET, SOCK_STREAM, 0)
+        let listenerFD = sysSocket(AF_INET, sysSockStream, 0)
         guard listenerFD >= 0 else { return nil }
 
         var addr = sockaddr_in()
@@ -114,11 +191,11 @@ final class TCPProbeTests: XCTestCase {
 
         let bindResult = withUnsafePointer(to: &addr) { addrPtr -> Int32 in
             addrPtr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockAddrPtr in
-                Darwin.bind(listenerFD, sockAddrPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+                sysBind(listenerFD, sockAddrPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
-        guard bindResult == 0, Darwin.listen(listenerFD, 4) == 0 else {
-            Darwin.close(listenerFD)
+        guard bindResult == 0, sysListen(listenerFD, 4) == 0 else {
+            _ = sysClose(listenerFD)
             return nil
         }
 
@@ -126,11 +203,11 @@ final class TCPProbeTests: XCTestCase {
         var len = socklen_t(MemoryLayout<sockaddr_in>.size)
         let nameResult = withUnsafeMutablePointer(to: &boundAddr) { ptr -> Int32 in
             ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockAddrPtr in
-                Darwin.getsockname(listenerFD, sockAddrPtr, &len)
+                sysGetsockname(listenerFD, sockAddrPtr, &len)
             }
         }
         guard nameResult == 0 else {
-            Darwin.close(listenerFD)
+            _ = sysClose(listenerFD)
             return nil
         }
 
@@ -346,6 +423,16 @@ final class VersionPromptPolicyTests: XCTestCase {
             dismissedPermanently: false
         ))
     }
+
+    /// A single-component current version ("3") can't be parsed into
+    /// major.minor — the policy must fail closed rather than prompt.
+    func testSingleComponentCurrentVersionFailsClosed() {
+        XCTAssertFalse(VersionPromptPolicy.shouldPrompt(
+            currentVersion: "3",
+            lastSeenVersion: "2.3.0",
+            dismissedPermanently: false
+        ))
+    }
 }
 
 final class CustomPingTargetStoreTests: XCTestCase {
@@ -421,6 +508,17 @@ final class CustomPingTargetStoreTests: XCTestCase {
         let longHost = String(repeating: "x", count: 300)
         XCTAssertEqual(
             CustomPingTargetStore.validate(displayName: "X", host: longHost, port: 53),
+            .hostTooLong
+        )
+    }
+
+    /// Exactly 255 characters is the RFC 1035 limit and must be accepted;
+    /// 256 must be rejected.
+    func testValidationHostLengthBoundary() {
+        let boundaryHost = String(repeating: "x", count: CustomPingTargetStore.maxHostnameLength)
+        XCTAssertNil(CustomPingTargetStore.validate(displayName: "X", host: boundaryHost, port: 53))
+        XCTAssertEqual(
+            CustomPingTargetStore.validate(displayName: "X", host: boundaryHost + "x", port: 53),
             .hostTooLong
         )
     }

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,60 @@
 # Ping Warden Worklog
 
+## 2026-07-03 - 2.5.0: Full reliability audit (helper/XPC/widget/monitoring/tooling)
+
+**What changed**:
+- Ran a comprehensive multi-agent audit of the entire codebase and fixed
+  every verified finding (~30 files). Highlights: quit no longer persists
+  protection off; helper exit paths guarantee awdl0 restore via a direct
+  ioctl fallback (`restoreInterfaceUpDirectly`); `setAwdlEnabled` fails
+  loudly when the poll thread is dead; XPC retry counter resets only after
+  a validated helper response (fixes an infinite silent reconnect loop);
+  abandoned XPC connections are invalidated; registration polling is
+  main-confined and always delivers its completion; helper exit decision is
+  atomic with connection counting; release helper builds fail closed on
+  signature-validation failure; game-category detection matches
+  subcategories (`…-games`); Game Mode vs. quick-pause restore matrix fixed;
+  Control Center toggle kept in sync via app-side `reloadControls` and
+  intent-only display; widget launch failures roll back and surface;
+  TCPProbe measures handshake-only latency with deadline-bounded DNS on a
+  detached thread (IP literals resolve inline) and uses poll(2), making the
+  core package Linux-portable; saved GFN/gateway target selection survives
+  relaunch; failed GFN refresh keeps prior zones; chart history memoized +
+  downsampled (spikes preserved); dashboard target dedup everywhere;
+  bounded auto-select fan-out; atomic CustomPingTargetStore mutations;
+  Sparkle starts after first-run setup; settings frame autosave preserved;
+  release.sh/notarize.sh/create-dmg.sh hardening (Sentry fail-soft actually
+  fail-soft, untracked beta appcast push, `--prerelease` for betas,
+  per-version GitHub notes via `render_release_notes.sh --markdown`,
+  RFC-822 pubDate, mandatory version args cross-checked against Info.plist).
+- CI: new `linux-core-tests` job (swift:5.10 container) + shellcheck for all
+  five scripts. Tests 33 → 41, all green on Linux and macOS.
+- Bumped to 2.5.0 (Info.plist ×3, MARKETING_VERSION ×4, helper fallback
+  macro) and added the RELEASE_NOTES.md section.
+
+**Decisions made**:
+- Widget toggle now displays/toggles user *intent* (not effective||intent):
+  the composite made disable snap back visually and made the Shortcuts
+  toggle unable to turn off auto-enabled protection.
+- Left `MINIMUM_SYSTEM_VERSION=26.0` in release.sh untouched (flagged in the
+  PR): all 2.4.x appcast items carry it, so it reads as deliberate, but it
+  contradicts the documented macOS 13+ support — maintainer call.
+- Widget appex stays unsandboxed (intent launches the app via NSWorkspace);
+  flagged, not changed.
+
+**Verification**:
+- `swift test` 41/41 on Linux; `swiftc -parse` on every edited Swift file;
+  `bash -n` on all scripts; CI green on the PR branch (build + linux tests +
+  shell-lint). The app target itself still needs the maintainer's macOS
+  Release archive for full compile verification.
+
+**Left off at**: PR #34 (draft) open with everything above; release-side
+prep done. Signing/notarization must run on the Mac with the Developer ID
+cert, notarytool profile, and Sparkle key: merge, then the standard headless
+archive + `release.sh 2.5.0 ../../RELEASE_NOTES.md` flow from CLAUDE.md.
+
+---
+
 ## 2026-06-22 - 2.4.3: Settings-scene crash fix + headless release path proven
 
 **What changed**:

--- a/scripts/render_release_notes.sh
+++ b/scripts/render_release_notes.sh
@@ -11,8 +11,12 @@
 # so Sparkle's update window shows real release notes instead of "See release
 # notes on GitHub". Also usable standalone for previewing.
 #
-# Usage: ./scripts/render_release_notes.sh <version>
+# Usage: ./scripts/render_release_notes.sh <version> [--markdown]
 # Example: ./scripts/render_release_notes.sh 2.3.0
+#
+# --markdown prints the raw extracted markdown section instead of rendered
+# HTML (used by release.sh for the GitHub release body, so each release page
+# shows only its own notes rather than the whole history file).
 #
 # Copyright (c) 2025-2026 Oliver Ames. All rights reserved.
 # Licensed under the MIT License.
@@ -21,8 +25,9 @@
 set -euo pipefail
 
 VERSION="${1:-}"
+OUTPUT_MODE="${2:-}"
 if [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>" >&2
+    echo "Usage: $0 <version> [--markdown]" >&2
     exit 1
 fi
 
@@ -35,7 +40,7 @@ if [ ! -f "$RELEASE_NOTES_FILE" ]; then
     exit 1
 fi
 
-if ! command -v gh >/dev/null 2>&1; then
+if [ "$OUTPUT_MODE" != "--markdown" ] && ! command -v gh >/dev/null 2>&1; then
     echo "Error: gh CLI required for markdown rendering" >&2
     exit 1
 fi
@@ -56,6 +61,11 @@ SECTION=$(printf '%s\n' "$SECTION" | awk 'NF{p=1}p' | awk 'BEGIN{n=0} {a[n++]=$0
 if [ -z "$SECTION" ]; then
     echo "Error: no release notes found for version '$VERSION' in RELEASE_NOTES.md" >&2
     exit 2
+fi
+
+if [ "$OUTPUT_MODE" = "--markdown" ]; then
+    printf '%s\n' "$SECTION"
+    exit 0
 fi
 
 # Render markdown → HTML using gh's /markdown endpoint. The `gfm` mode matches


### PR DESCRIPTION
## Summary

A full audit of the app (privileged helper, XPC layer, widget sync, monitoring pipeline, app lifecycle, release scripts, CI, tests), with every verified finding fixed. Version bumped to **2.5.0** across all targets; release notes added.

### Protection reliability
- Quitting the app no longer flips the monitoring preference off — protection restores after a normal quit + relaunch (`applicationWillTerminate` now uses `persistUserPreference: false`)
- Helper exit paths (grace-period shutdown, SIGTERM) guarantee awdl0 is restored via a new direct-ioctl fallback (`restoreInterfaceUpDirectly`), even if the poll thread died or the pipe write failed
- `setAwdlEnabled:` fails loudly when the poll thread is dead instead of "succeeding" into a readerless pipe
- XPC retry counter now resets only after the helper answers a validation ping — fixes an infinite silent reconnect loop; abandoned connections are explicitly invalidated (mach resource leak); reassert-after-reconnect re-checks for a racing stop
- Registration polling is main-thread confined and always delivers its completion — `isRegisteringHelper` can no longer wedge permanently
- Helper exit decision is atomic with connection counting (`isExiting` flag + synchronous counting); exit timer confined to the main queue; service/listener anchored in immortal globals (ARC lifetime hazard)
- Release builds of the root helper fail closed if self code-signing validation fails (DEBUG builds keep the UID-only fallback)

### Game Mode & quick pause
- Game detection now matches `LSApplicationCategoryType` subcategories (`…action-games`, `…role-playing-games`, …) — previously most categorized games were never detected
- Pause started *during* Game Mode is honored at game end; a pre-game pause that expires mid-game restores from user intent instead of leaving protection off permanently
- Quick-pause auto-resume timer runs in `.common` mode; status-menu items enable/disable correctly (`autoenablesItems = false`)

### Control Center widget
- The main app now reloads the control whenever monitoring state changes (menu bar, Settings, Game Mode) — the toggle can no longer display stale state indefinitely
- The widget displays and toggles the same state (user intent): fixes the off-toggle snap-back and a Shortcuts toggle that could never disable auto-enabled protection
- App-launch failure rolls back the intent and throws `appLaunchFailed` instead of silently reporting success
- Widget preferences: thread-safe non-lazy suite handle; refuses to toggle into split-brain state if the App Group suite is unavailable
- Lockout invariant enforced continuously: the dock icon cannot be hidden while Control Center mode has the menu bar icon removed

### Monitoring & dashboard
- `TCPProbe` measures only the successful TCP handshake — DNS time and failed dual-stack attempts no longer inflate "successful" pings (~1010 ms artifacts) that poisoned averages, jitter, spike events, and Auto-Select rankings
- DNS resolution is bounded by a deadline on a detached thread — a hung resolver can no longer freeze the whole probe pipeline/dashboard
- Saved GeForce NOW zone / local-gateway selection survives relaunch (pending-selection slot re-applied when async sources land); failed GFN refresh keeps previously discovered zones
- Chart history memoized + downsampled to ≤720 points (spikes always preserved) — major CPU reduction during long sessions; target lists deduplicated at every assembly site
- `PingMonitor.start()` no longer silently retargets a running monitor; `currentPing` reports the last *successful* sample; intervention baseline resets on dashboard close; auto-select probes moved off the Swift-concurrency cooperative pool; `CustomPingTargetStore` mutations are atomic; XPC backoff capped at 30 s

### App/support
- Sparkle updater starts as soon as first-run helper registration completes (was silently disabled for the whole first session)
- Settings window size/position survives relaunch (launch-time cleanup excludes the autosave key; `center()` before `setFrameAutosaveName`)
- Quarantine help builds the `xattr` command from the actual bundle path and runs signature checks off the main thread; diagnostics export enforces its background-thread contract in Release and falls back to the temp dir on Desktop-write failure

### Tooling, CI, tests
- **Core package is now cross-platform** (`#if canImport(Darwin)/Glibc`, `poll(2)` instead of `select(2)`); new `ubuntu-latest` `swift test` CI job; shellcheck covers all five scripts
- 8 new tests (41 total, all passing): `.fair` band, min/max, all-failures, single-sample jitter, backoff cap + monotonicity, single-component version fail-closed, 255-char host boundary
- `release.sh`: Sentry failure can no longer abort before the gh-pages appcast push; first-ever beta appcast publishes (untracked-file check); betas marked `--prerelease`; GitHub release bodies use only that version's notes (`render_release_notes.sh --markdown`); RFC-822-safe `pubDate`; loud stash/checkout recovery
- `notarize.sh` / `create-dmg.sh`: version argument required + cross-checked against Info.plist; notarytool diagnostics survive `set -e`; missing `create-dmg.sh` or missing DMG is an error; deep-verify avoids the SIGPIPE/pipefail trap

### Flagged, not changed
- `release.sh` defaults `MINIMUM_SYSTEM_VERSION=26.0` (all 2.4.x appcast items carry it) while `Package.swift`/CLAUDE.md say macOS 13+ — if 13–15 users should receive updates, override `MINIMUM_SYSTEM_VERSION` at release time.
- The widget appex ships unsandboxed (`com.apple.security.app-sandbox = false`); it appears intentional (the intent launches the main app via `NSWorkspace`), left as-is.

## Verification
- `swift test`: **41/41 pass** (run on Linux via the now-portable core package)
- `swiftc -parse` clean on every edited Swift file; `bash -n` clean on every edited script
- The macOS app/helper targets need a macOS build to fully verify — CI's helper build + the maintainer's release archive cover that

## Release
Code-side release prep is complete (version 2.5.0 in all three Info.plists, 4× `MARKETING_VERSION`, helper fallback macro, RELEASE_NOTES.md). Signing/notarization requires the Mac with the Developer ID cert + notarytool profile + Sparkle key; after merging, run the standard headless flow from CLAUDE.md:

```bash
xcodebuild archive -project PingWarden.xcodeproj -scheme PingWarden -configuration Release \
  -archivePath /tmp/PingWarden-2.5.0.xcarchive -destination 'generic/platform=macOS' \
  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO
rsync -a "/tmp/PingWarden-2.5.0.xcarchive/Products/Applications/Ping Warden.app/" "PingWarden/build/Ping Warden.app/"
cd PingWarden/PingWarden && bash release.sh 2.5.0 ../../RELEASE_NOTES.md
git add appcast.xml && git commit -m "Update appcast for v2.5.0" && git push
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Na5ufwLdjLfuSucR5hVgdn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Na5ufwLdjLfuSucR5hVgdn)_