### PR TITLE
Apply pending dependency updates together

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Show Xcode version
       run: xcodebuild -version
@@ -106,7 +106,7 @@ jobs:
     container: swift:5.10
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Run core logic tests
       run: swift test
@@ -115,7 +115,7 @@ jobs:
     runs-on: macos-26
     steps:
     - name: Checkout
-      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     - name: Install shellcheck
       run: brew install shellcheck

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,4 +42,4 @@ jobs:
             ONLY_ACTIVE_ARCH=NO
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
         with:
           languages: swift,c-cpp
           queries: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4

--- a/PingWarden/PingWarden.xcodeproj/project.pbxproj
+++ b/PingWarden/PingWarden.xcodeproj/project.pbxproj
@@ -754,7 +754,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.13.0;
+				minimumVersion = 9.22.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PingWarden/PingWarden.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/PingWarden/PingWarden.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa",
       "state" : {
-        "revision" : "64c9c5cc401aefde0eda46a9192b36082533a79d",
-        "version" : "9.13.0"
+        "revision" : "67310f115f3fc1e5e1f2e262f9009c64bb387e3f",
+        "version" : "9.22.0"
       }
     },
     {


### PR DESCRIPTION
This combines the four pending Dependabot updates into one tested change.

The separate CodeQL PRs failed because the init and analyze steps used different patch versions. This updates both steps together, along with actions/checkout and Sentry Cocoa.

Local verification:
- 79 Swift tests pass
- workflow YAML parses
- release shell scripts pass syntax and shellcheck validation

This replaces #37, #38, #39, and #40.